### PR TITLE
test: e2e smoke test with test bot and acp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -22,3 +22,4 @@ jobs:
       - run: pnpm i
       - run: pnpm lint-check
       - run: pnpm tsc
+      - run: pnpm test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@
 | ----------------------- | ---------------------------- |
 | `pnpm start`            | Run daemon (requires `.env`) |
 | `pnpm dev`              | Run daemon with --watch      |
+| `pnpm test`             | E2E smoke test (vitest)      |
 | `pnpm lint && pnpm tsc` | Lint                         |
 
 ## Key Docs

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -1,5 +1,6 @@
 # TODO
 
+- [ ] chore: replace "daemon" with "service"
 - [ ] feat: telegram integration
   - [x] Receive text messages, reply with agent response
   - [x] Sender allowlist (user + chat)

--- a/docs/tasks/2026-04-09-e2e-test.md
+++ b/docs/tasks/2026-04-09-e2e-test.md
@@ -1,0 +1,87 @@
+# E2E-ish Test Architecture
+
+Test the real daemon process end-to-end by sandwiching it between two fakes, switched via env vars only.
+
+```
+[Fake Telegram API]  ←→  acpella daemon (real process)  ←→  [Fake ACP agent via acpx]
+        ↕
+   test driver
+```
+
+## Approach
+
+No interfaces, no DI, no refactoring. Two env vars control the fakes:
+
+- `TELEGRAM_API_ROOT` — point grammy at a local fake HTTP server instead of `api.telegram.org`
+- `AGENT=fake-echo` — point acpx at a trivial ACP-compatible agent
+
+## Fake 1: Telegram API server
+
+grammy supports `new Bot(token, { client: { apiRoot } })`.
+
+**Production code change**: read `TELEGRAM_API_ROOT` env var, pass to Bot constructor. ~3 lines.
+
+Fake server implements minimal subset via `node:http`:
+
+- `POST /bot<token>/getMe` — return dummy bot user (grammy calls on startup)
+- `POST /bot<token>/getUpdates` — long-polling. Test driver pushes fake updates, bot consumes them
+- `POST /bot<token>/sendMessage` — capture replies for assertion
+
+Test driver interface (conceptual):
+
+```ts
+const tg = createFakeTelegramServer();
+await tg.sendUpdate({ message: { text: "hello", chat: { id: 123 }, from: { id: 456 } } });
+const reply = await tg.waitForSendMessage();
+assert(reply.text.includes("expected"));
+```
+
+## Fake 2: ACP agent
+
+Trivial script that speaks ACP protocol. acpx launches it like a real agent.
+
+**Echo agent**: returns input as output via JSONRPC `agent_message_chunk` lines in the expected format.
+
+**Open question**: Does acpx support registering a custom agent binary, or do we need to shim it? Check `acpx` docs/config. Worst case, a wrapper script in PATH named `fake-echo`.
+
+## Test flow
+
+```
+1. Start fake Telegram server on random port
+2. Start daemon as child process:
+     TELEGRAM_BOT_TOKEN=test-token
+     TELEGRAM_API_ROOT=http://localhost:<port>
+     AGENT=fake-echo
+     ALLOWED_USER_IDS=456
+     DAEMON_CWD=/tmp/test
+3. Push fake Telegram update (user message "hello")
+4. Wait for daemon to call sendMessage on fake server
+5. Assert reply matches expected echo
+6. Kill daemon, tear down
+```
+
+## Coverage
+
+| Scenario                                  | Covered?                            |
+| ----------------------------------------- | ----------------------------------- |
+| Full message flow: receive → acpx → reply | ✅                                  |
+| Allowlist filtering (user/chat)           | ✅                                  |
+| `/status` command                         | ✅                                  |
+| Session naming (chat, thread)             | ✅                                  |
+| Error handling (agent failure)            | ✅ (fake agent can exit with error) |
+| JSONRPC parsing                           | ✅ (fake agent emits real format)   |
+| Real Telegram API                         | ❌ (grammy's job)                   |
+| Real agent quality                        | ❌ (agent's job)                    |
+
+## Tooling
+
+- **Test runner**: vitest
+- **Fake Telegram server**: `node:http`, no extra deps
+- **Fake agent**: single `.ts` script
+- **Daemon under test**: spawned as child process with test env vars
+
+## Production code changes
+
+1. `src/index.ts`: read `TELEGRAM_API_ROOT` env var, pass as `apiRoot` to `Bot` constructor
+
+That's it.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "node --env-file=.env src/index.ts",
     "dev": "node --env-file=.env --watch src/index.ts",
     "repl": "ACPELLA_TEST_BOT=1 node src/index.ts",
-    "dev-repl": "ACPELLA_TEST_BOT=1 node --watch src/index.ts",
+    "test": "vitest",
     "tsc": "tsc -b",
     "lint": "vp fmt",
     "lint-check": "vp fmt --check"
@@ -19,7 +19,8 @@
   "devDependencies": {
     "@types/node": "^24.12.2",
     "typescript": "^6.0.2",
-    "vite-plus": "^0.1.16"
+    "vite-plus": "^0.1.16",
+    "vitest": "^4.1.4"
   },
   "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319"
 }

--- a/package.json
+++ b/package.json
@@ -17,10 +17,12 @@
     "grammy": "^1.42.0"
   },
   "devDependencies": {
+    "@agentclientprotocol/sdk": "^0.18.2",
     "@types/node": "^24.12.2",
     "typescript": "^6.0.2",
     "vite-plus": "^0.1.16",
-    "vitest": "^4.1.4"
+    "vitest": "^4.1.4",
+    "zod": "^4.3.6"
   },
   "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319"
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
     "prepare": "vp config",
     "start": "node --env-file=.env src/index.ts",
     "dev": "node --env-file=.env --watch src/index.ts",
+    "repl": "ACPELLA_TEST_BOT=1 node src/index.ts",
+    "dev-repl": "ACPELLA_TEST_BOT=1 node --watch src/index.ts",
     "tsc": "tsc -b",
     "lint": "vp fmt",
     "lint-check": "vp fmt --check"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,9 @@ importers:
         specifier: ^1.42.0
         version: 1.42.0
     devDependencies:
+      '@agentclientprotocol/sdk':
+        specifier: ^0.18.2
+        version: 0.18.2(zod@4.3.6)
       '@types/node':
         specifier: ^24.12.2
         version: 24.12.2
@@ -27,11 +30,19 @@ importers:
       vitest:
         specifier: ^4.1.4
         version: 4.1.4(@types/node@24.12.2)(vite@8.0.8(@types/node@24.12.2)(tsx@4.21.0))
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
 
 packages:
 
   '@agentclientprotocol/sdk@0.17.1':
     resolution: {integrity: sha512-yjyIn8POL18IOXioLySYiL0G44kZ/IZctAls7vS3AC3X+qLhFXbWmzABSZehwRnWFShMXT+ODa/HJG1+mGXZ1A==}
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+
+  '@agentclientprotocol/sdk@0.18.2':
+    resolution: {integrity: sha512-l/o9NKvUc00GPa6RFJ4AccQq2O/PAf83xQ75mThHuL3H571iN4+PEdwnTBez67sS8Nv2aSA373xCZ5CbTXEwzA==}
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 
@@ -1278,6 +1289,10 @@ packages:
 snapshots:
 
   '@agentclientprotocol/sdk@0.17.1(zod@4.3.6)':
+    dependencies:
+      zod: 4.3.6
+
+  '@agentclientprotocol/sdk@0.18.2(zod@4.3.6)':
     dependencies:
       zod: 4.3.6
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
       vite-plus:
         specifier: ^0.1.16
         version: 0.1.16(@types/node@24.12.2)(tsx@4.21.0)(typescript@6.0.2)(vite@8.0.8(@types/node@24.12.2)(tsx@4.21.0))
+      vitest:
+        specifier: ^4.1.4
+        version: 4.1.4(@types/node@24.12.2)(vite@8.0.8(@types/node@24.12.2)(tsx@4.21.0))
 
 packages:
 
@@ -205,6 +208,9 @@ packages:
 
   '@grammyjs/types@3.26.0':
     resolution: {integrity: sha512-jlnyfxfev/2o68HlvAGRocAXgdPPX5QabG7jZlbqC2r9DZyWBfzTlg+nu3O3Fy4EhgLWu28hZ/8wr7DsNamP9A==}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
   '@napi-rs/wasm-runtime@1.1.3':
     resolution: {integrity: sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==}
@@ -609,8 +615,40 @@ packages:
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
   '@types/node@24.12.2':
     resolution: {integrity: sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==}
+
+  '@vitest/expect@4.1.4':
+    resolution: {integrity: sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==}
+
+  '@vitest/mocker@4.1.4':
+    resolution: {integrity: sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.4':
+    resolution: {integrity: sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==}
+
+  '@vitest/runner@4.1.4':
+    resolution: {integrity: sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==}
+
+  '@vitest/snapshot@4.1.4':
+    resolution: {integrity: sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==}
+
+  '@vitest/spy@4.1.4':
+    resolution: {integrity: sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==}
+
+  '@vitest/utils@4.1.4':
+    resolution: {integrity: sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==}
 
   '@voidzero-dev/vite-plus-core@0.1.16':
     resolution: {integrity: sha512-fOyf14CXjcXqANFs2fCXEX+0Tn9ZjmqfFV+qTnARwIF1Kzl8WquO4XtvlDgs/fTQ91H4AyoNUgkvWdKS+C4xYA==}
@@ -811,9 +849,16 @@ packages:
   bare-url@2.4.0:
     resolution: {integrity: sha512-NSTU5WN+fy/L0DDenfE8SXQna4voXuW0FHM7wH8i3/q9khUSchfPbPezO4zSFMnDGIf9YE+mt/RWhZgNRKRIXA==}
 
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
   commander@14.0.3:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
     engines: {node: '>=20'}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -831,10 +876,16 @@ packages:
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
+  es-module-lexer@2.0.0:
+    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
+
   esbuild@0.27.7:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
     engines: {node: '>=18'}
     hasBin: true
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
   event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
@@ -842,6 +893,10 @@ packages:
 
   events-universal@1.0.1:
     resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   fast-fifo@1.3.2:
     resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
@@ -950,6 +1005,9 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
     engines: {node: '>=10'}
@@ -993,6 +1051,9 @@ packages:
       oxlint-tsgolint:
         optional: true
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -1020,6 +1081,9 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   sirv@3.0.2:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
     engines: {node: '>=18'}
@@ -1035,6 +1099,9 @@ packages:
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
   std-env@4.0.0:
     resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
@@ -1065,6 +1132,10 @@ packages:
   tinypool@2.1.0:
     resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
     engines: {node: ^20.0.0 || >=22.0.0}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
@@ -1137,11 +1208,57 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.1.4:
+    resolution: {integrity: sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.4
+      '@vitest/browser-preview': 4.1.4
+      '@vitest/browser-webdriverio': 4.1.4
+      '@vitest/coverage-istanbul': 4.1.4
+      '@vitest/coverage-v8': 4.1.4
+      '@vitest/ui': 4.1.4
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
 
   ws@8.20.0:
     resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
@@ -1271,6 +1388,8 @@ snapshots:
     optional: true
 
   '@grammyjs/types@3.26.0': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@napi-rs/wasm-runtime@1.1.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
     dependencies:
@@ -1484,9 +1603,52 @@ snapshots:
 
   '@types/deep-eql@4.0.2': {}
 
+  '@types/estree@1.0.8': {}
+
   '@types/node@24.12.2':
     dependencies:
       undici-types: 7.16.0
+
+  '@vitest/expect@4.1.4':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.4
+      '@vitest/utils': 4.1.4
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.4(vite@8.0.8(@types/node@24.12.2)(tsx@4.21.0))':
+    dependencies:
+      '@vitest/spy': 4.1.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.8(@types/node@24.12.2)(tsx@4.21.0)
+
+  '@vitest/pretty-format@4.1.4':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.4':
+    dependencies:
+      '@vitest/utils': 4.1.4
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.4':
+    dependencies:
+      '@vitest/pretty-format': 4.1.4
+      '@vitest/utils': 4.1.4
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.4': {}
+
+  '@vitest/utils@4.1.4':
+    dependencies:
+      '@vitest/pretty-format': 4.1.4
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   '@voidzero-dev/vite-plus-core@0.1.16(@types/node@24.12.2)(tsx@4.21.0)(typescript@6.0.2)':
     dependencies:
@@ -1615,7 +1777,11 @@ snapshots:
     dependencies:
       bare-path: 3.0.0
 
+  chai@6.2.2: {}
+
   commander@14.0.3: {}
+
+  convert-source-map@2.0.0: {}
 
   debug@4.4.3:
     dependencies:
@@ -1624,6 +1790,8 @@ snapshots:
   detect-libc@2.1.2: {}
 
   es-module-lexer@1.7.0: {}
+
+  es-module-lexer@2.0.0: {}
 
   esbuild@0.27.7:
     optionalDependencies:
@@ -1654,6 +1822,10 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.7
       '@esbuild/win32-x64': 0.27.7
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   event-target-shim@5.0.1: {}
 
   events-universal@1.0.1:
@@ -1661,6 +1833,8 @@ snapshots:
       bare-events: 2.8.2
     transitivePeerDependencies:
       - bare-abort-controller
+
+  expect-type@1.3.0: {}
 
   fast-fifo@1.3.2: {}
 
@@ -1744,6 +1918,10 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   mrmime@2.0.1: {}
 
   ms@2.1.3: {}
@@ -1812,6 +1990,8 @@ snapshots:
       '@oxlint/binding-win32-x64-msvc': 1.58.0
       oxlint-tsgolint: 0.20.0
 
+  pathe@2.0.3: {}
+
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
@@ -1851,6 +2031,8 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.15
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.15
 
+  siginfo@2.0.0: {}
+
   sirv@3.0.2:
     dependencies:
       '@polka/url': 1.0.0-next.29
@@ -1869,6 +2051,8 @@ snapshots:
       - react-native-b4a
 
   source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
 
   std-env@4.0.0: {}
 
@@ -1915,6 +2099,8 @@ snapshots:
       picomatch: 4.0.4
 
   tinypool@2.1.0: {}
+
+  tinyrainbow@3.1.0: {}
 
   totalist@3.0.1: {}
 
@@ -1991,12 +2177,44 @@ snapshots:
       fsevents: 2.3.3
       tsx: 4.21.0
 
+  vitest@4.1.4(@types/node@24.12.2)(vite@8.0.8(@types/node@24.12.2)(tsx@4.21.0)):
+    dependencies:
+      '@vitest/expect': 4.1.4
+      '@vitest/mocker': 4.1.4(vite@8.0.8(@types/node@24.12.2)(tsx@4.21.0))
+      '@vitest/pretty-format': 4.1.4
+      '@vitest/runner': 4.1.4
+      '@vitest/snapshot': 4.1.4
+      '@vitest/spy': 4.1.4
+      '@vitest/utils': 4.1.4
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.8(@types/node@24.12.2)(tsx@4.21.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.12.2
+    transitivePeerDependencies:
+      - msw
+
   webidl-conversions@3.0.1: {}
 
   whatwg-url@5.0.0:
     dependencies:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   ws@8.20.0: {}
 

--- a/src/e2e/basic.test.ts
+++ b/src/e2e/basic.test.ts
@@ -11,4 +11,14 @@ describe("e2e smoke", () => {
 
     await daemon.stop();
   });
+
+  it("echo agent round-trip", async () => {
+    const daemon = startDaemon({ AGENT: "node src/test-agent.ts" });
+
+    await daemon.waitForLine("Starting daemon");
+    daemon.send("hello world");
+    await daemon.waitForLine("echo: hello world");
+
+    await daemon.stop();
+  }, 30_000);
 });

--- a/src/e2e/basic.test.ts
+++ b/src/e2e/basic.test.ts
@@ -1,0 +1,14 @@
+import { describe, it } from "vitest";
+import { startDaemon } from "./helper.ts";
+
+describe("e2e smoke", () => {
+  it("starts and responds to /status", async () => {
+    const daemon = startDaemon();
+
+    await daemon.waitForLine("Starting daemon");
+    daemon.send("/status");
+    await daemon.waitForLine("configured agent: codex");
+
+    await daemon.stop();
+  });
+});

--- a/src/e2e/basic.test.ts
+++ b/src/e2e/basic.test.ts
@@ -20,5 +20,5 @@ describe("e2e smoke", () => {
     await daemon.waitForLine("echo: hello world");
 
     await daemon.stop();
-  }, 30_000);
+  });
 });

--- a/src/e2e/helper.ts
+++ b/src/e2e/helper.ts
@@ -1,0 +1,62 @@
+import { spawn } from "node:child_process";
+
+export function startDaemon(env?: Record<string, string>) {
+  const child = spawn("node", ["src/index.ts"], {
+    cwd: import.meta.dirname + "/../..",
+    env: {
+      ...process.env,
+      ACPELLA_TEST_BOT: "1",
+      AGENT: "codex",
+      ...env,
+    },
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+
+  const lines: string[] = [];
+  let buf = "";
+
+  child.stdout.on("data", (chunk: Buffer) => {
+    buf += chunk.toString();
+    const parts = buf.split("\n");
+    buf = parts.pop()!;
+    for (const line of parts) {
+      lines.push(line);
+    }
+  });
+
+  async function waitForLine(match: string | RegExp, timeoutMs = 5000): Promise<string> {
+    const found = lines.find((l) =>
+      typeof match === "string" ? l.includes(match) : match.test(l),
+    );
+    if (found) return found;
+
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        reject(new Error(`Timed out waiting for "${match}". Lines so far:\n${lines.join("\n")}`));
+      }, timeoutMs);
+
+      const check = () => {
+        const idx = lines.findIndex((l) =>
+          typeof match === "string" ? l.includes(match) : match.test(l),
+        );
+        if (idx >= 0) {
+          clearTimeout(timer);
+          child.stdout.off("data", check);
+          resolve(lines[idx]);
+        }
+      };
+      child.stdout.on("data", check);
+    });
+  }
+
+  function send(text: string) {
+    child.stdin.write(text + "\n");
+  }
+
+  async function stop() {
+    child.stdin.end();
+    await new Promise<void>((resolve) => child.on("close", resolve));
+  }
+
+  return { child, lines, send, waitForLine, stop };
+}

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -1,0 +1,98 @@
+import { execFile } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+// use local dep binary instead of npx
+const ACPX_BIN = fileURLToPath(new URL("../node_modules/.bin/acpx", import.meta.url));
+
+// --- acpx ---
+
+async function ensureSession(_sessionName: string, agent: string, cwd: string): Promise<void> {
+  await execFileAsync(
+    ACPX_BIN,
+    [
+      "--cwd",
+      cwd,
+      "--approve-all",
+      agent,
+      "sessions",
+      "ensure",
+      // TODO: named session not working?
+      // "--name", sessionName,
+    ],
+    {
+      timeout: 60_000,
+      env: { ...process.env },
+    },
+  );
+}
+
+async function acpxPrompt(
+  sessionName: string,
+  text: string,
+  agent: string,
+  cwd: string,
+): Promise<string> {
+  await ensureSession(sessionName, agent, cwd);
+
+  const { stdout } = await execFileAsync(
+    ACPX_BIN,
+    [
+      "--approve-all",
+      "--format",
+      "json",
+      agent,
+      // TODO: named session not working?
+      // "-s", sessionName,
+      "prompt",
+      text,
+    ],
+    {
+      timeout: 300_000, // 5 min
+      maxBuffer: 10 * 1024 * 1024,
+      env: { ...process.env },
+    },
+  );
+
+  // parse JSONRPC envelope output — extract agent text chunks
+  const lines = stdout.trim().split("\n");
+  const texts: string[] = [];
+  for (const line of lines) {
+    try {
+      const msg = JSON.parse(line);
+      const update = msg.params?.update;
+      if (update?.sessionUpdate === "agent_message_chunk" && update.content?.type === "text") {
+        texts.push(update.content.text);
+      }
+    } catch {
+      // skip non-json lines
+    }
+  }
+  return texts.join("") || "(no response)";
+}
+
+// --- handler ---
+
+export interface HandlerConfig {
+  agent: string;
+  cwd: string;
+}
+
+export function formatStatus(agent: string, cwd: string): string {
+  return ["daemon state: running", `configured agent: ${agent}`, `working directory: ${cwd}`].join(
+    "\n",
+  );
+}
+
+export function createHandler(
+  config: HandlerConfig,
+): (text: string, session: string) => Promise<string> {
+  return async (text, session) => {
+    if (text === "/status") {
+      return formatStatus(config.agent, config.cwd);
+    }
+    return acpxPrompt(session, text, config.agent, config.cwd);
+  };
+}

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -9,14 +9,22 @@ const ACPX_BIN = fileURLToPath(new URL("../node_modules/.bin/acpx", import.meta.
 
 // --- acpx ---
 
-async function ensureSession(_sessionName: string, agent: string, cwd: string): Promise<void> {
+function acpxAgentArgs(agent: string): string[] {
+  return agent.includes("/") ? ["--agent", agent] : [agent];
+}
+
+async function ensureSession(
+  _sessionName: string,
+  agentArgs: string[],
+  cwd: string,
+): Promise<void> {
   await execFileAsync(
     ACPX_BIN,
     [
       "--cwd",
       cwd,
       "--approve-all",
-      agent,
+      ...agentArgs,
       "sessions",
       "ensure",
       // TODO: named session not working?
@@ -32,10 +40,10 @@ async function ensureSession(_sessionName: string, agent: string, cwd: string): 
 async function acpxPrompt(
   sessionName: string,
   text: string,
-  agent: string,
+  agentArgs: string[],
   cwd: string,
 ): Promise<string> {
-  await ensureSession(sessionName, agent, cwd);
+  await ensureSession(sessionName, agentArgs, cwd);
 
   const { stdout } = await execFileAsync(
     ACPX_BIN,
@@ -43,7 +51,7 @@ async function acpxPrompt(
       "--approve-all",
       "--format",
       "json",
-      agent,
+      ...agentArgs,
       // TODO: named session not working?
       // "-s", sessionName,
       "prompt",
@@ -86,13 +94,22 @@ export function formatStatus(agent: string, cwd: string): string {
   );
 }
 
-export function createHandler(
-  config: HandlerConfig,
-): (text: string, session: string) => Promise<string> {
-  return async (text, session) => {
-    if (text === "/status") {
-      return formatStatus(config.agent, config.cwd);
-    }
-    return acpxPrompt(session, text, config.agent, config.cwd);
+export function createHandler(config?: Partial<HandlerConfig>): {
+  handle: (text: string, session: string) => Promise<string>;
+  config: HandlerConfig;
+} {
+  const resolved: HandlerConfig = {
+    agent: config?.agent ?? process.env.AGENT ?? "codex",
+    cwd: config?.cwd ?? process.env.DAEMON_CWD ?? process.cwd(),
   };
+  const agentArgs = acpxAgentArgs(resolved.agent);
+
+  const handle = async (text: string, session: string) => {
+    if (text === "/status") {
+      return formatStatus(resolved.agent, resolved.cwd);
+    }
+    return acpxPrompt(session, text, agentArgs, resolved.cwd);
+  };
+
+  return { handle, config: resolved };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,11 +2,6 @@ import { Bot } from "grammy";
 import { createHandler } from "./handler.ts";
 import { createTestBot, startTestBotRepl } from "./test-bot.ts";
 
-function sessionName(chatId: number, threadId?: number): string {
-  const base = `tg-${chatId}`;
-  return threadId ? `${base}-${threadId}` : base;
-}
-
 function main() {
   const agent = process.env.AGENT ?? "codex";
   const cwd = process.env.DAEMON_CWD ?? process.cwd();
@@ -75,6 +70,11 @@ function main() {
   } else {
     bot.start();
   }
+}
+
+function sessionName(chatId: number, threadId?: number): string {
+  const base = `tg-${chatId}`;
+  return threadId ? `${base}-${threadId}` : base;
 }
 
 main();

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,8 @@ import { createTestBot, startTestBotRepl } from "./test-bot.ts";
 function main() {
   const agent = process.env.AGENT ?? "codex";
   const cwd = process.env.DAEMON_CWD ?? process.cwd();
+
+  // TODO: require ALLOWED_USER_IDS
   const allowedUsers = new Set(
     (process.env.ALLOWED_USER_IDS ?? "").split(",").filter(Boolean).map(Number),
   );
@@ -18,7 +20,7 @@ function main() {
 
   const testMode = !!process.env.ACPELLA_TEST_BOT;
   let bot: Bot;
-  // impor type { TestBot }
+  // TODO: import type { TestBot }
   let testBot: ReturnType<typeof createTestBot> | undefined;
 
   if (testMode) {
@@ -28,7 +30,8 @@ function main() {
     const token = process.env.TELEGRAM_BOT_TOKEN;
     if (!token) {
       console.error("TELEGRAM_BOT_TOKEN is required");
-      process.exit(1);
+      process.exitCode = 1;
+      return;
     }
     bot = new Bot(token, {
       client: { apiRoot: process.env.TELEGRAM_API_ROOT },

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,8 +3,8 @@ import { createHandler } from "./handler.ts";
 import { createTestBot, startTestBotRepl } from "./test-bot.ts";
 
 function main() {
-  const agent = process.env.AGENT ?? "codex";
-  const cwd = process.env.DAEMON_CWD ?? process.cwd();
+  const { handle, config: handlerConfig } = createHandler();
+  const { agent, cwd } = handlerConfig;
 
   // TODO: require ALLOWED_USER_IDS
   const allowedUsers = new Set(
@@ -13,8 +13,6 @@ function main() {
   const allowedChats = new Set(
     (process.env.ALLOWED_CHAT_IDS ?? "").split(",").filter(Boolean).map(Number),
   );
-
-  const handle = createHandler({ agent, cwd });
 
   // --- create bot (real or test) ---
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,101 +1,13 @@
-import { execFile } from "node:child_process";
-import { fileURLToPath } from "node:url";
-import { promisify } from "node:util";
 import { Bot } from "grammy";
-
-const execFileAsync = promisify(execFile);
-
-// use local dep binary instead of npx
-const ACPX_BIN = fileURLToPath(new URL("../node_modules/.bin/acpx", import.meta.url));
-
-// --- acpx ---
-
-async function ensureSession(_sessionName: string, agent: string, cwd: string): Promise<void> {
-  await execFileAsync(
-    ACPX_BIN,
-    [
-      "--cwd",
-      cwd,
-      "--approve-all",
-      agent,
-      "sessions",
-      "ensure",
-      // TODO: named session not working?
-      // "--name", sessionName,
-    ],
-    {
-      timeout: 60_000,
-      env: { ...process.env },
-    },
-  );
-}
-
-async function acpxPrompt(
-  sessionName: string,
-  text: string,
-  agent: string,
-  cwd: string,
-): Promise<string> {
-  await ensureSession(sessionName, agent, cwd);
-
-  const { stdout } = await execFileAsync(
-    ACPX_BIN,
-    [
-      "--approve-all",
-      "--format",
-      "json",
-      agent,
-      // TODO: named session not working?
-      // "-s", sessionName,
-      "prompt",
-      text,
-    ],
-    {
-      timeout: 300_000, // 5 min
-      maxBuffer: 10 * 1024 * 1024,
-      env: { ...process.env },
-    },
-  );
-
-  // parse JSONRPC envelope output — extract agent text chunks
-  const lines = stdout.trim().split("\n");
-  const texts: string[] = [];
-  for (const line of lines) {
-    try {
-      const msg = JSON.parse(line);
-      const update = msg.params?.update;
-      if (update?.sessionUpdate === "agent_message_chunk" && update.content?.type === "text") {
-        texts.push(update.content.text);
-      }
-    } catch {
-      // skip non-json lines
-    }
-  }
-  return texts.join("") || "(no response)";
-}
-
-// --- telegram ---
+import { createHandler } from "./handler.ts";
+import { createTestBot, startTestBotRepl } from "./test-bot.ts";
 
 function sessionName(chatId: number, threadId?: number): string {
   const base = `tg-${chatId}`;
   return threadId ? `${base}-${threadId}` : base;
 }
 
-function formatStatus(agent: string, cwd: string): string {
-  return ["daemon state: running", `configured agent: ${agent}`, `working directory: ${cwd}`].join(
-    "\n",
-  );
-}
-
-// --- main ---
-
 function main() {
-  const token = process.env.TELEGRAM_BOT_TOKEN;
-  if (!token) {
-    console.error("TELEGRAM_BOT_TOKEN is required");
-    process.exit(1);
-  }
-
   const agent = process.env.AGENT ?? "codex";
   const cwd = process.env.DAEMON_CWD ?? process.cwd();
   const allowedUsers = new Set(
@@ -105,7 +17,30 @@ function main() {
     (process.env.ALLOWED_CHAT_IDS ?? "").split(",").filter(Boolean).map(Number),
   );
 
-  const bot = new Bot(token);
+  const handle = createHandler({ agent, cwd });
+
+  // --- create bot (real or test) ---
+
+  const testMode = !!process.env.ACPELLA_TEST_BOT;
+  let bot: Bot;
+  // impor type { TestBot }
+  let testBot: ReturnType<typeof createTestBot> | undefined;
+
+  if (testMode) {
+    testBot = createTestBot();
+    bot = testBot.bot;
+  } else {
+    const token = process.env.TELEGRAM_BOT_TOKEN;
+    if (!token) {
+      console.error("TELEGRAM_BOT_TOKEN is required");
+      process.exit(1);
+    }
+    bot = new Bot(token, {
+      client: { apiRoot: process.env.TELEGRAM_API_ROOT },
+    });
+  }
+
+  // --- wire handler (shared between real and test) ---
 
   bot.on("message:text", async (ctx) => {
     const userId = ctx.from?.id;
@@ -121,12 +56,7 @@ function main() {
     console.log(`[${name}] <- ${text}`);
 
     try {
-      if (text === "/status") {
-        await ctx.reply(formatStatus(agent, cwd));
-        return;
-      }
-
-      const response = await acpxPrompt(name, text, agent, cwd);
+      const response = await handle(text, name);
       console.log(`[${name}] -> ${response.slice(0, 100)}...`);
       await ctx.reply(response);
     } catch (err) {
@@ -136,8 +66,15 @@ function main() {
     }
   });
 
-  console.log(`Starting daemon (agent: ${agent}, cwd: ${cwd})`);
-  bot.start();
+  // --- start ---
+
+  console.log(`Starting daemon (agent: ${agent}, cwd: ${cwd}, test: ${testMode})`);
+
+  if (testBot) {
+    startTestBotRepl(testBot);
+  } else {
+    bot.start();
+  }
 }
 
 main();

--- a/src/test-agent.ts
+++ b/src/test-agent.ts
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+
+// Minimal ACP-compatible echo agent for testing.
+// Echoes back the prompt text as an agent_message_chunk.
+
+import {
+  AgentSideConnection,
+  ndJsonStream,
+  PROTOCOL_VERSION,
+  type Agent,
+  type InitializeRequest,
+  type InitializeResponse,
+  type NewSessionRequest,
+  type NewSessionResponse,
+  type AuthenticateRequest,
+  type AuthenticateResponse,
+  type SetSessionModeRequest,
+  type SetSessionModeResponse,
+  type PromptRequest,
+  type PromptResponse,
+  type CancelNotification,
+} from "@agentclientprotocol/sdk";
+import { Readable, Writable } from "node:stream";
+
+class EchoAgent implements Agent {
+  private connection: AgentSideConnection;
+
+  constructor(connection: AgentSideConnection) {
+    this.connection = connection;
+  }
+
+  async initialize(_params: InitializeRequest): Promise<InitializeResponse> {
+    return {
+      protocolVersion: PROTOCOL_VERSION,
+      agentCapabilities: { loadSession: false },
+    };
+  }
+
+  async newSession(_params: NewSessionRequest): Promise<NewSessionResponse> {
+    const sessionId = crypto.randomUUID();
+    return { sessionId };
+  }
+
+  async authenticate(_params: AuthenticateRequest): Promise<AuthenticateResponse> {
+    return {};
+  }
+
+  async setSessionMode(_params: SetSessionModeRequest): Promise<SetSessionModeResponse> {
+    return {};
+  }
+
+  async prompt(params: PromptRequest): Promise<PromptResponse> {
+    // Echo the prompt text back
+    const text =
+      params.prompt
+        .filter((c) => c.type === "text")
+        .map((c) => c.text)
+        .join("") || "(empty)";
+
+    await this.connection.sessionUpdate({
+      sessionId: params.sessionId,
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text: `echo: ${text}` },
+      },
+    });
+
+    return { stopReason: "end_turn" };
+  }
+
+  async cancel(_params: CancelNotification): Promise<void> {}
+}
+
+const input = Writable.toWeb(process.stdout);
+const output = Readable.toWeb(process.stdin) as ReadableStream<Uint8Array>;
+const stream = ndJsonStream(input, output);
+new AgentSideConnection((conn) => new EchoAgent(conn), stream);

--- a/src/test-bot.ts
+++ b/src/test-bot.ts
@@ -87,8 +87,10 @@ export async function startTestBotRepl(testBot: TestBot): Promise<void> {
         console.log(r.text);
       }
     }
-  } catch {
+  } catch (e) {
+    // TODO: silence only abort. surface others
     // Ctrl+D throws AbortError — treat as exit
+    console.error(e);
   } finally {
     rl.close();
   }

--- a/src/test-bot.ts
+++ b/src/test-bot.ts
@@ -77,17 +77,21 @@ export async function startTestBotRepl(testBot: TestBot): Promise<void> {
   const rl = createInterface({ input: process.stdin, output: process.stdout });
   const { replies, sendMessage } = testBot;
 
-  while (true) {
-    const text = await rl.question("> ");
-    if (!text || text === "/quit") break;
-    replies.length = 0;
-    await sendMessage(text);
-    for (const r of replies) {
-      console.log(r.text);
+  try {
+    while (true) {
+      const text = await rl.question("> ");
+      if (!text || text === "/quit") break;
+      replies.length = 0;
+      await sendMessage(text);
+      for (const r of replies) {
+        console.log(r.text);
+      }
     }
+  } catch {
+    // Ctrl+D throws AbortError — treat as exit
+  } finally {
+    rl.close();
   }
-
-  rl.close();
 }
 
 // TODO: fix error on ctrl-D

--- a/src/test-bot.ts
+++ b/src/test-bot.ts
@@ -1,0 +1,119 @@
+// In-process test bot: real grammy Bot, fake transport.
+// Bot receives updates via handleUpdate(), replies are captured in-memory.
+// Activated from index.ts via ACPELLA_TEST_BOT=1.
+
+import { createInterface } from "node:readline/promises";
+import { Bot } from "grammy";
+import type { Update, UserFromGetMe } from "grammy/types";
+
+const botInfo: UserFromGetMe = {
+  id: 1,
+  is_bot: true,
+  first_name: "TestBot",
+  username: "test_bot",
+  can_join_groups: true,
+  can_read_all_group_messages: false,
+  can_manage_bots: false,
+  supports_inline_queries: false,
+  can_connect_to_business: false,
+  has_main_web_app: false,
+  has_topics_enabled: false,
+  allows_users_to_create_topics: false,
+};
+
+export interface TestBot {
+  bot: Bot;
+  replies: { chatId: number; text: string }[];
+  sendMessage: (
+    text: string,
+    opts?: { chatId?: number; userId?: number; threadId?: number },
+  ) => Promise<void>;
+}
+
+export function createTestBot(): TestBot {
+  const replies: { chatId: number; text: string }[] = [];
+
+  const bot = new Bot("test-token", { botInfo });
+
+  // intercept outgoing API calls — capture replies instead of hitting Telegram
+  bot.api.config.use(async (prev, method, payload) => {
+    if (method === "sendMessage") {
+      const p = payload as Record<string, unknown>;
+      replies.push({ chatId: p.chat_id as number, text: p.text as string });
+      return {
+        ok: true as const,
+        result: { message_id: 1, date: Date.now() / 1000, chat: { id: p.chat_id } },
+      } as never;
+    }
+    return prev(method, payload);
+  });
+
+  let updateId = 1;
+
+  return {
+    bot,
+    replies,
+    async sendMessage(text, opts) {
+      const chatId = opts?.chatId ?? 123;
+      const userId = opts?.userId ?? 456;
+      const update: Update = {
+        update_id: updateId++,
+        message: {
+          message_id: updateId,
+          date: Math.floor(Date.now() / 1000),
+          chat: { id: chatId, type: "private" as const, first_name: "Test" },
+          from: { id: userId, is_bot: false, first_name: "Test" },
+          text,
+          ...(opts?.threadId ? { message_thread_id: opts.threadId } : {}),
+        },
+      };
+      await bot.handleUpdate(update);
+    },
+  };
+}
+
+/** Start interactive REPL for a wired test bot */
+export async function startTestBotRepl(testBot: TestBot): Promise<void> {
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  const { replies, sendMessage } = testBot;
+
+  while (true) {
+    const text = await rl.question("> ");
+    if (!text || text === "/quit") break;
+    replies.length = 0;
+    await sendMessage(text);
+    for (const r of replies) {
+      console.log(r.text);
+    }
+  }
+
+  rl.close();
+}
+
+// TODO: fix error on ctrl-D
+// ~/code/personal/acpella $ pnpm repl
+
+// > acpella@ repl /home/hiroshi/code/personal/acpella
+// > ACPELLA_TEST_BOT=1 node src/index.ts
+
+// Starting daemon (agent: codex, cwd: /home/hiroshi/code/personal/acpella, test: true)
+// > node:internal/readline/interface:1343
+//             this[kQuestionReject]?.(new AbortError('Aborted with Ctrl+D'));
+//                                     ^
+
+// AbortError: Aborted with Ctrl+D
+//     at [_ttyWrite] (node:internal/readline/interface:1343:37)
+//     at ReadStream.onkeypress (node:internal/readline/interface:284:20)
+//     at ReadStream.emit (node:events:508:28)
+//     at emitKeys (node:internal/readline/utils:371:14)
+//     at emitKeys.next (<anonymous>)
+//     at ReadStream.onData (node:internal/readline/emitKeypressEvents:64:36)
+//     at ReadStream.emit (node:events:508:28)
+//     at addChunk (node:internal/streams/readable:563:12)
+//     at readableAddChunkPushByteMode (node:internal/streams/readable:514:3)
+//     at Readable.push (node:internal/streams/readable:394:5) {
+//   code: 'ABORT_ERR'
+// }
+
+// Node.js v24.14.1
+//  ELIFECYCLE  Command failed with exit code 1.

--- a/src/test-bot.ts
+++ b/src/test-bot.ts
@@ -88,38 +88,10 @@ export async function startTestBotRepl(testBot: TestBot): Promise<void> {
       }
     }
   } catch (e) {
-    // TODO: silence only abort. surface others
-    // Ctrl+D throws AbortError — treat as exit
-    console.error(e);
+    if (!(e instanceof Error && e.name === "AbortError")) {
+      throw e;
+    }
   } finally {
     rl.close();
   }
 }
-
-// TODO: fix error on ctrl-D
-// ~/code/personal/acpella $ pnpm repl
-
-// > acpella@ repl /home/hiroshi/code/personal/acpella
-// > ACPELLA_TEST_BOT=1 node src/index.ts
-
-// Starting daemon (agent: codex, cwd: /home/hiroshi/code/personal/acpella, test: true)
-// > node:internal/readline/interface:1343
-//             this[kQuestionReject]?.(new AbortError('Aborted with Ctrl+D'));
-//                                     ^
-
-// AbortError: Aborted with Ctrl+D
-//     at [_ttyWrite] (node:internal/readline/interface:1343:37)
-//     at ReadStream.onkeypress (node:internal/readline/interface:284:20)
-//     at ReadStream.emit (node:events:508:28)
-//     at emitKeys (node:internal/readline/utils:371:14)
-//     at emitKeys.next (<anonymous>)
-//     at ReadStream.onData (node:internal/readline/emitKeypressEvents:64:36)
-//     at ReadStream.emit (node:events:508:28)
-//     at addChunk (node:internal/streams/readable:563:12)
-//     at readableAddChunkPushByteMode (node:internal/streams/readable:514:3)
-//     at Readable.push (node:internal/streams/readable:394:5) {
-//   code: 'ABORT_ERR'
-// }
-
-// Node.js v24.14.1
-//  ELIFECYCLE  Command failed with exit code 1.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,7 +4,9 @@ export default defineConfig({
   test: {
     dir: "./src",
   },
-  fmt: {},
+  fmt: {
+    ignorePatterns: ["./refs/**"],
+  },
   staged: {
     "*": "vp check --no-lint --fix",
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,11 @@
 import { defineConfig } from "vite-plus";
 
 export default defineConfig({
+  test: {
+    dir: "./src",
+  },
+  fmt: {},
   staged: {
     "*": "vp check --no-lint --fix",
   },
-  fmt: {},
 });


### PR DESCRIPTION
## Summary

- Extract `createHandler` from `src/index.ts` into `src/handler.ts` so the core logic is reusable
- Add `src/test-bot.ts`: in-process grammy Bot with fake transport (`handleUpdate` + API transformer), activated via `ACPELLA_TEST_BOT=1` env var
- `src/index.ts` switches between real Telegram and test-bot REPL based on env var — same handler wiring either way
- E2E smoke test in `src/e2e/basic.test.ts`: spawns `node src/index.ts` as a child process, drives it via stdin/stdout, asserts on output
- Add vitest, task doc for the test architecture

## Test plan

- [x] `npx vitest run src/e2e/basic.test.ts` passes
- [x] `pnpm tsc` clean
- [x] `ACPELLA_TEST_BOT=1 node src/index.ts` works as interactive REPL

🤖 Generated with [Claude Code](https://claude.com/claude-code)