### PR TITLE
chore: replace daemon terminology with service

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,12 +2,12 @@
 
 ## Quick Reference
 
-| Command      | When                         |
-| ------------ | ---------------------------- |
-| `pnpm start` | Run daemon (requires `.env`) |
-| `pnpm dev`   | Run daemon with --watch      |
-| `pnpm test`  | E2E smoke test (vitest)      |
-| `pnpm lint`  | Lint                         |
+| Command      | When                          |
+| ------------ | ----------------------------- |
+| `pnpm start` | Run service (requires `.env`) |
+| `pnpm dev`   | Run service with --watch      |
+| `pnpm test`  | E2E smoke test (vitest)       |
+| `pnpm lint`  | Lint                          |
 
 ## Key Docs
 
@@ -20,9 +20,9 @@
 
 ## Architecture
 
-Thin daemon: Telegram ↔ acpx ↔ coding agent (Codex, Claude Code, etc.).
+Thin service: Telegram ↔ acpx ↔ coding agent (Codex, Claude Code, etc.).
 
-- **`src/index.ts`** — single-file daemon: config, acpx interface, telegram bot, entry point
+- **`src/index.ts`** — single-file service: config, acpx interface, telegram bot, entry point
 
 Each Telegram chat maps to a named acpx session (`tg-<chatId>`). Forum threads get `tg-<chatId>-<threadId>`. The agent (acpx) runs as a subprocess; its binary is at `node_modules/.bin/acpx`.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # acpella
 
-Thin daemon that connects a messaging channel (Telegram) to a coding agent via [ACP](https://github.com/agentclientprotocol/agent-client-protocol). Agent-agnostic — works with Codex, Claude Code, or any ACP-compatible agent.
+Thin service that connects a messaging channel (Telegram) to a coding agent via [ACP](https://github.com/agentclientprotocol/agent-client-protocol). Agent-agnostic — works with Codex, Claude Code, or any ACP-compatible agent.
 
 ## Setup
 
@@ -13,7 +13,7 @@ cp .env.example .env
 ## Run
 
 ```bash
-pnpm start        # run daemon
+pnpm start        # run service
 pnpm dev          # run with --watch
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # acpella
 
-Thin service that connects a messaging channel (Telegram) to a coding agent via [ACP](https://github.com/agentclientprotocol/agent-client-protocol). Agent-agnostic — works with Codex, Claude Code, or any ACP-compatible agent.
+Thin service that connects a messaging channel (Telegram) to AI agent via [ACP](https://github.com/agentclientprotocol/agent-client-protocol). Agent-agnostic — works with Codex, Claude Code, or any ACP-compatible agent.
 
 ## Setup
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,22 +2,22 @@
 
 ## Overview
 
-acpella is a thin daemon that bridges a messaging channel (Telegram) to a coding agent via ACP (Agent Client Protocol). It replaces OpenClaw with ~150 lines by delegating all agent complexity to acpx.
+acpella is a thin service that bridges a messaging channel (Telegram) to a coding agent via ACP (Agent Client Protocol). It replaces OpenClaw with ~150 lines by delegating all agent complexity to acpx.
 
 ```
 Telegram  ──►  acpella  ──►  acpx  ──►  agent (Codex, Claude Code, ...)
-              (daemon)     (CLI)        (ACP subprocess)
+              (service)    (CLI)        (ACP subprocess)
 ```
 
-**Why ACP**: ACP is the protocol Zed, Cursor, and other editors use to talk to coding agents. By speaking ACP, acpella is agent-agnostic — swap `ACPELLA_AGENT=codex` for `ACPELLA_AGENT=claude` without changing the daemon. The agent binary manages its own session state, tool execution, and memory.
+**Why ACP**: ACP is the protocol Zed, Cursor, and other editors use to talk to coding agents. By speaking ACP, acpella is agent-agnostic — swap `ACPELLA_AGENT=codex` for `ACPELLA_AGENT=claude` without changing the service. The agent binary manages its own session state, tool execution, and memory.
 
-**Why acpx**: acpx is a standalone ACP client CLI. acpella shells out to it instead of speaking ACP directly, which keeps the daemon code minimal and offloads session management to acpx.
+**Why acpx**: acpx is a standalone ACP client CLI. acpella shells out to it instead of speaking ACP directly, which keeps the service code minimal and offloads session management to acpx.
 
 ## Components
 
 ### `src/index.ts`
 
-Single-file daemon. Three sections:
+Single-file service. Three sections:
 
 **acpx interface** — `ensureSession` and `acpxPrompt` shell out to `node_modules/.bin/acpx`. `acpxPrompt` runs `acpx ... prompt <text>` with `--format json`, capturing stdout as JSONRPC-envelope newline-delimited JSON, then extracts `agent_message_chunk` text to assemble the response.
 
@@ -42,7 +42,7 @@ acpxPrompt(sessionName, text)
   │
   └─► acpx --format json <agent> prompt <text>
         agent runs, streams JSONRPC lines to stdout
-        daemon collects agent_message_chunk lines → joins text
+        service collects agent_message_chunk lines → joins text
   │
   ▼
 ctx.reply(response)
@@ -82,8 +82,8 @@ acpella extracts text by filtering `params.update.sessionUpdate === "agent_messa
 
 ## Key decisions
 
-**Single file** — the daemon is small enough that modules add indirection without benefit. Split when it grows.
+**Single file** — the service is small enough that modules add indirection without benefit. Split when it grows.
 
 **Shell out to acpx** — avoids owning the ACP client/session lifecycle. Tradeoff: subprocess overhead per prompt, no streaming to Telegram. Acceptable for a personal assistant.
 
-**No database** — session state lives in acpx. Memory lives in the agent's working directory (`ACPELLA_HOME`). The daemon is stateless and restartable.
+**No database** — session state lives in acpx. Memory lives in the agent's working directory (`ACPELLA_HOME`). The service is stateless and restartable.

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -17,7 +17,7 @@ cp .env.example .env
 ```ini
 # /etc/systemd/system/acpella.service
 [Unit]
-Description=acpella daemon
+Description=acpella service
 After=network.target
 
 [Service]
@@ -25,7 +25,7 @@ Type=simple
 User=hiroshi
 WorkingDirectory=/home/hiroshi/code/personal/acpella
 EnvironmentFile=/home/hiroshi/code/personal/acpella/.env
-ExecStart=/usr/bin/node src/daemon.ts
+ExecStart=/usr/bin/node src/index.ts
 Restart=on-failure
 RestartSec=10
 

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -1,6 +1,6 @@
 # TODO
 
-- [ ] chore: replace "daemon" with "service"
+- [x] chore: replace "daemon" with "service"
 - [ ] feat: telegram integration
   - [x] Receive text messages, reply with agent response
   - [x] Sender allowlist (user + chat)

--- a/src/e2e/basic.test.ts
+++ b/src/e2e/basic.test.ts
@@ -1,24 +1,24 @@
 import { describe, it } from "vitest";
-import { startDaemon } from "./helper.ts";
+import { startService } from "./helper.ts";
 
 describe("e2e smoke", () => {
   it("starts and responds to /status", async () => {
-    const daemon = startDaemon();
+    const service = startService();
 
-    await daemon.waitForLine("Starting daemon");
-    daemon.send("/status");
-    await daemon.waitForLine("configured agent: codex");
+    await service.waitForLine("Starting service");
+    service.send("/status");
+    await service.waitForLine("configured agent: codex");
 
-    await daemon.stop();
+    await service.stop();
   });
 
   it("echo agent round-trip", async () => {
-    const daemon = startDaemon({ ACPELLA_AGENT: "node src/test-agent.ts" });
+    const service = startService({ ACPELLA_AGENT: "node src/test-agent.ts" });
 
-    await daemon.waitForLine("Starting daemon");
-    daemon.send("hello world");
-    await daemon.waitForLine("echo: hello world");
+    await service.waitForLine("Starting service");
+    service.send("hello world");
+    await service.waitForLine("echo: hello world");
 
-    await daemon.stop();
+    await service.stop();
   });
 });

--- a/src/e2e/codex/basic.test.ts
+++ b/src/e2e/codex/basic.test.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 import { beforeAll, it, vi } from "vitest";
 import { ACPX_BIN } from "../../handler.ts";
 import { spawnAsync } from "../../spawn.ts";
-import { startDaemon } from "../helper.ts";
+import { startService } from "../helper.ts";
 
 const FIXTURES_DIR = path.join(import.meta.dirname, "fixtures");
 const TEST_CHAT_ID = `10101010`;
@@ -34,14 +34,14 @@ beforeAll(async () => {
 });
 
 it("round-trip with real codex", async ({ onTestFinished }) => {
-  const daemon = startDaemon({
+  const service = startService({
     ACPELLA_HOME: FIXTURES_DIR,
     ACPELLA_TEST_CHAT_ID: TEST_CHAT_ID,
   });
   onTestFinished(async () => {
-    await daemon.stop();
+    await service.stop();
   });
-  await daemon.waitForLine("Starting daemon");
-  daemon.send("reply with exactly: pong");
-  await daemon.waitForLine("pong");
+  await service.waitForLine("Starting service");
+  service.send("reply with exactly: pong");
+  await service.waitForLine("pong");
 });

--- a/src/e2e/helper.ts
+++ b/src/e2e/helper.ts
@@ -2,7 +2,7 @@ import { spawn } from "node:child_process";
 
 // TODO: review slop
 
-export function startDaemon(env?: Record<string, string>) {
+export function startService(env?: Record<string, string>) {
   const child = spawn("node", ["src/index.ts"], {
     cwd: import.meta.dirname + "/../..",
     env: {

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -93,7 +93,7 @@ export interface HandlerConfig {
 }
 
 export function formatStatus(agent: string, cwd: string): string {
-  return ["daemon state: running", `configured agent: ${agent}`, `working directory: ${cwd}`].join(
+  return ["service state: running", `configured agent: ${agent}`, `working directory: ${cwd}`].join(
     "\n",
   );
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,7 +69,7 @@ async function main() {
 
   // --- start ---
 
-  console.log(`Starting daemon (agent: ${agent}, cwd: ${cwd}, test: ${testMode})`);
+  console.log(`Starting service (agent: ${agent}, cwd: ${cwd}, test: ${testMode})`);
 
   if (testBot) {
     await startTestBotRepl(testBot);


### PR DESCRIPTION
## Summary
- Replace active user-facing and code terminology from "daemon" to "service"
- Rename E2E helper usage from `startDaemon` to `startService`
- Mark the PRD chore complete and update the deploy entry point to `src/index.ts`

## Tests
- `pnpm lint`
- `pnpm test`