### PR TITLE
fix: handle ACP stderr and exit

### DIFF
--- a/src/acp/index.ts
+++ b/src/acp/index.ts
@@ -72,7 +72,9 @@ async function spawnAgent({ command, cwd }: { command: string; cwd: string }) {
   // handle process exit
   const child = spawn(cmd, args, { stdio: ["pipe", "pipe", "pipe"], cwd });
   const earlyExit = createEarlyExitPromise(child);
-  pipeAgentStderr(child.stderr);
+  if (child.stderr) {
+    pipeAgentStderr(child.stderr);
+  }
 
   const stream = ndJsonStream(
     Writable.toWeb(child.stdin!),
@@ -153,11 +155,7 @@ function createEarlyExitPromise(child: ChildProcess): {
   };
 }
 
-function pipeAgentStderr(stderr: Readable | undefined | null): void {
-  if (!stderr) {
-    return;
-  }
-
+function pipeAgentStderr(stderr: Readable): void {
   let buffered = "";
   stderr.setEncoding("utf8");
   stderr.on("data", (chunk) => {

--- a/src/acp/index.ts
+++ b/src/acp/index.ts
@@ -68,8 +68,6 @@ type SpanwedAgent = Awaited<ReturnType<typeof spawnAgent>>;
 
 async function spawnAgent({ command, cwd }: { command: string; cwd: string }) {
   const [cmd, ...args] = command.trim().split(/\s+/);
-  // TODO:
-  // handle process exit
   const child = spawn(cmd, args, { stdio: ["pipe", "pipe", "pipe"], cwd });
   const earlyExit = createEarlyExitPromise(child);
   if (child.stderr) {
@@ -203,5 +201,3 @@ async function createSession(options: { agent: SpanwedAgent; sessionId: string }
     },
   };
 }
-
-export type AcpSession = Awaited<ReturnType<typeof createSession>>;

--- a/src/acp/index.ts
+++ b/src/acp/index.ts
@@ -1,4 +1,4 @@
-import { spawn } from "node:child_process";
+import { spawn, type ChildProcess } from "node:child_process";
 import { Readable, Writable } from "node:stream";
 import {
   ClientSideConnection,
@@ -71,6 +71,7 @@ async function spawnAgent({ command, cwd }: { command: string; cwd: string }) {
   // TODO:
   // handle process exit
   const child = spawn(cmd, args, { stdio: ["pipe", "pipe", "pipe"], cwd });
+  const earlyExit = createEarlyExitPromise(child);
   pipeAgentStderr(child.stderr);
 
   const stream = ndJsonStream(
@@ -97,10 +98,17 @@ async function spawnAgent({ command, cwd }: { command: string; cwd: string }) {
   };
 
   const connection = new ClientSideConnection(() => client, stream);
-  await connection.initialize({
-    protocolVersion: PROTOCOL_VERSION,
-    clientCapabilities: {},
-  });
+  try {
+    await Promise.race([
+      connection.initialize({
+        protocolVersion: PROTOCOL_VERSION,
+        clientCapabilities: {},
+      }),
+      earlyExit.promise,
+    ]);
+  } finally {
+    earlyExit.cleanup();
+  }
 
   function subscribe(listener: (update: SessionUpdate) => void) {
     listeners.add(listener);
@@ -108,6 +116,41 @@ async function spawnAgent({ command, cwd }: { command: string; cwd: string }) {
   }
 
   return { child, connection, subscribe };
+}
+
+function createEarlyExitPromise(child: ChildProcess): {
+  promise: Promise<never>;
+  cleanup: () => void;
+} {
+  let onError: (error: Error) => void;
+  let onExit: (code: number | null, signal: NodeJS.Signals | null) => void;
+
+  const promise = new Promise<never>((_, reject) => {
+    onError = (error) => {
+      reject(new Error(`ACP agent failed to start: ${error.message}`));
+    };
+
+    onExit = (code, signal) => {
+      reject(
+        new Error(
+          `ACP agent exited before initialize completed: code=${code ?? "none"} signal=${
+            signal ?? "none"
+          }`,
+        ),
+      );
+    };
+
+    child.once("error", onError);
+    child.once("exit", onExit);
+  });
+
+  return {
+    promise,
+    cleanup() {
+      child.off("error", onError);
+      child.off("exit", onExit);
+    },
+  };
 }
 
 function pipeAgentStderr(stderr: Readable | undefined | null): void {

--- a/src/acp/index.ts
+++ b/src/acp/index.ts
@@ -69,9 +69,9 @@ type SpanwedAgent = Awaited<ReturnType<typeof spawnAgent>>;
 async function spawnAgent({ command, cwd }: { command: string; cwd: string }) {
   const [cmd, ...args] = command.trim().split(/\s+/);
   // TODO:
-  // handle stderr
   // handle process exit
-  const child = spawn(cmd, args, { stdio: ["pipe", "pipe", "inherit"], cwd });
+  const child = spawn(cmd, args, { stdio: ["pipe", "pipe", "pipe"], cwd });
+  pipeAgentStderr(child.stderr);
 
   const stream = ndJsonStream(
     Writable.toWeb(child.stdin!),
@@ -108,6 +108,30 @@ async function spawnAgent({ command, cwd }: { command: string; cwd: string }) {
   }
 
   return { child, connection, subscribe };
+}
+
+function pipeAgentStderr(stderr: Readable | undefined | null): void {
+  if (!stderr) {
+    return;
+  }
+
+  let buffered = "";
+  stderr.setEncoding("utf8");
+  stderr.on("data", (chunk) => {
+    buffered += String(chunk);
+    let newlineIndex = buffered.indexOf("\n");
+    while (newlineIndex !== -1) {
+      const line = buffered.slice(0, newlineIndex).replace(/\r$/, "");
+      console.error(`[acp:stderr] ${line}`);
+      buffered = buffered.slice(newlineIndex + 1);
+      newlineIndex = buffered.indexOf("\n");
+    }
+  });
+  stderr.on("end", () => {
+    if (buffered) {
+      console.error(`[acp:stderr] ${buffered.replace(/\r$/, "")}`);
+    }
+  });
 }
 
 async function createSession(options: { agent: SpanwedAgent; sessionId: string }) {

--- a/src/e2e/basic.test.ts
+++ b/src/e2e/basic.test.ts
@@ -23,4 +23,15 @@ describe("e2e smoke", () => {
     service.send("hello world");
     await service.waitForLine("echo: hello world");
   });
+
+  it("reports agent startup failure", async ({ onTestFinished }) => {
+    const service = startService({ ACPELLA_AGENT: "no-such-command" });
+    onTestFinished(async () => {
+      await service.stop();
+    });
+
+    await service.waitForLine("Starting service");
+    service.send("hello world");
+    await service.waitForLine("Error: ACP agent failed to start: spawn no-such-command ENOENT");
+  });
 });


### PR DESCRIPTION
## Summary
- Pipe ACP agent stderr instead of inheriting raw stderr
- Re-emit stderr lines with an `[acp:stderr]` prefix
- Race ACP initialization against child `error`/`exit` events to report agents that fail before initialize completes

## Tests
- pnpm lint
- pnpm test