### PR TITLE
feat: add custom prompt file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,17 @@ pnpm cli --repl # run local in-process REPL
 
 ## Config
 
-| Variable                            | Required | Default                         | Description                                |
-| ----------------------------------- | -------- | ------------------------------- | ------------------------------------------ |
-| `ACPELLA_TELEGRAM_BOT_TOKEN`        | yes      | —                               | Bot token from @BotFather                  |
-| `ACPELLA_TELEGRAM_ALLOWED_USER_IDS` | yes      | —                               | Comma-separated numeric Telegram user IDs  |
-| `ACPELLA_TELEGRAM_ALLOWED_CHAT_IDS` | no       | —                               | Comma-separated chat IDs (group allowlist) |
-| `ACPELLA_AGENT`                     | no       | `npx @zed-industries/codex-acp` | acp agent command                          |
-| `ACPELLA_HOME`                      | no       | `process.cwd()`                 | Agent working directory                    |
+| Variable                            | Required | Default                         | Description                                   |
+| ----------------------------------- | -------- | ------------------------------- | --------------------------------------------- |
+| `ACPELLA_TELEGRAM_BOT_TOKEN`        | yes      | —                               | Bot token from @BotFather                     |
+| `ACPELLA_TELEGRAM_ALLOWED_USER_IDS` | yes      | —                               | Comma-separated numeric Telegram user IDs     |
+| `ACPELLA_TELEGRAM_ALLOWED_CHAT_IDS` | no       | —                               | Comma-separated chat IDs (group allowlist)    |
+| `ACPELLA_AGENT`                     | no       | `npx @zed-industries/codex-acp` | acp agent command                             |
+| `ACPELLA_HOME`                      | no       | `process.cwd()`                 | Agent working directory                       |
+| `ACPELLA_PROMPT_FILE`               | no       | —                               | Prompt file sent once when creating a session |
+
+Relative `ACPELLA_PROMPT_FILE` paths resolve from `ACPELLA_HOME`. If the prompt file changes,
+restart acpella and run `/session new` in the chat/thread that should use the new prompt.
 
 ## Docs
 

--- a/README.md
+++ b/README.md
@@ -28,9 +28,6 @@ pnpm cli --repl # run local in-process REPL
 | `ACPELLA_HOME`                      | no       | `process.cwd()`                 | Agent working directory                       |
 | `ACPELLA_PROMPT_FILE`               | no       | —                               | Prompt file sent once when creating a session |
 
-Relative `ACPELLA_PROMPT_FILE` paths resolve from `ACPELLA_HOME`. If the prompt file changes,
-restart acpella and run `/session new` in the chat/thread that should use the new prompt.
-
 ## Docs
 
 - [`docs/architecture.md`](docs/architecture.md) — design decisions, data flow

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,16 +2,16 @@
 
 ## Overview
 
-acpella is a thin service that bridges a messaging channel (Telegram) to a coding agent via ACP (Agent Client Protocol). It keeps the messaging layer small while delegating agent behavior, tools, and memory to an ACP-compatible agent.
+acpella is a thin service that bridges a messaging channel (Telegram) to a coding agent via ACP (Agent Client Protocol). It replaces OpenClaw with ~150 lines by delegating all agent complexity to acpx.
 
 ```
-Telegram  ──►  acpella  ──►  ACP agent (Codex, Claude Code, ...)
-              (service)      (subprocess)
+Telegram  ──►  acpella  ──►  acpx  ──►  agent (Codex, Claude Code, ...)
+              (service)    (CLI)        (ACP subprocess)
 ```
 
 **Why ACP**: ACP is the protocol Zed, Cursor, and other editors use to talk to coding agents. By speaking ACP, acpella is agent-agnostic — swap `ACPELLA_AGENT=codex` for `ACPELLA_AGENT=claude` without changing the service. The agent binary manages its own session state, tool execution, and memory.
 
-**Why direct ACP**: acpella spawns the configured ACP agent and talks to it through the ACP TypeScript SDK. acpella owns Telegram session mapping and lightweight persistence, while the agent owns actual reasoning and tool execution.
+**Why acpx**: acpx is a standalone ACP client CLI. acpella shells out to it instead of speaking ACP directly, which keeps the service code minimal and offloads session management to acpx.
 
 ## Components
 
@@ -19,7 +19,7 @@ Telegram  ──►  acpella  ──►  ACP agent (Codex, Claude Code, ...)
 
 Single-file service. Three sections:
 
-**ACP manager** — starts the configured agent subprocess, initializes ACP, creates or loads sessions, sends prompts, and extracts `agent_message_chunk` text to assemble the response.
+**acpx interface** — `ensureSession` and `acpxPrompt` shell out to `node_modules/.bin/acpx`. `acpxPrompt` runs `acpx ... prompt <text>` with `--format json`, capturing stdout as JSONRPC-envelope newline-delimited JSON, then extracts `agent_message_chunk` text to assemble the response.
 
 **Telegram** — grammy long-polling bot. One handler: `message:text`. Maps each chat/thread to a session name (`tg-<chatId>` or `tg-<chatId>-<threadId>`), calls `acpxPrompt`, replies with the result.
 
@@ -35,16 +35,14 @@ grammy bot handler
   │  checks allowlists (ACPELLA_TELEGRAM_ALLOWED_USER_IDS, ACPELLA_TELEGRAM_ALLOWED_CHAT_IDS)
   │  derives session name from chatId + threadId
   ▼
-handler(sessionName, text)
+acpxPrompt(sessionName, text)
   │
-  ├─► load existing session or create a new ACP session
+  ├─► ensureSession → acpx sessions ensure
+  │     starts agent subprocess if not running
   │
-  ├─► if new and ACPELLA_PROMPT_FILE is configured:
-  │     send initialization prompt
-  │
-  └─► send user prompt
-        agent streams session/update messages
-        service collects agent_message_chunk updates → joins text
+  └─► acpx --format json <agent> prompt <text>
+        agent runs, streams JSONRPC lines to stdout
+        service collects agent_message_chunk lines → joins text
   │
   ▼
 ctx.reply(response)
@@ -52,7 +50,7 @@ ctx.reply(response)
 
 ## Session model
 
-Each Telegram chat maps to one ACP session:
+Each Telegram chat maps to one acpx session:
 
 | Chat type    | Session name             |
 | ------------ | ------------------------ |
@@ -60,13 +58,11 @@ Each Telegram chat maps to one ACP session:
 | Group        | `tg-<chatId>`            |
 | Forum thread | `tg-<chatId>-<threadId>` |
 
-The session id is stored in `.acpella/state.json` under `ACPELLA_HOME`. `/session new` creates a
-fresh session for the current chat/thread. If `ACPELLA_PROMPT_FILE` is configured, the prompt file is
-sent once when a new session is created, including sessions created by `/session new`.
+`ensureSession` is called before every prompt — acpx is idempotent if the session already exists. The agent process runs as a long-lived subprocess managed by acpx; acpella does not own its lifecycle.
 
-## ACP updates
+## acpx output format
 
-The ACP agent emits `session/update` notifications:
+`acpx --format json` emits newline-delimited JSONRPC 2.0 envelopes:
 
 ```json
 {
@@ -82,15 +78,12 @@ The ACP agent emits `session/update` notifications:
 }
 ```
 
-acpella extracts text by filtering updates where `sessionUpdate === "agent_message_chunk"` and
-joining `content.text` chunks.
+acpella extracts text by filtering `params.update.sessionUpdate === "agent_message_chunk"` and joining `params.update.content.text` chunks.
 
 ## Key decisions
 
-**Direct ACP subprocess** — avoids depending on a separate CLI for prompt dispatch while keeping the service agent-agnostic.
+**Single file** — the service is small enough that modules add indirection without benefit. Split when it grows.
 
-**No database** — session mapping lives in `.acpella/state.json`. Agent memory lives in the agent's working directory (`ACPELLA_HOME`). The service remains restartable.
+**Shell out to acpx** — avoids owning the ACP client/session lifecycle. Tradeoff: subprocess overhead per prompt, no streaming to Telegram. Acceptable for a personal assistant.
 
-**Custom prompt file** — `ACPELLA_PROMPT_FILE` is sent as a normal ACP prompt turn when a session is
-created. Existing sessions are unchanged; restart acpella and run `/session new` to apply prompt file
-changes to a chat/thread.
+**No database** — session state lives in acpx. Memory lives in the agent's working directory (`ACPELLA_HOME`). The service is stateless and restartable.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,16 +2,16 @@
 
 ## Overview
 
-acpella is a thin service that bridges a messaging channel (Telegram) to a coding agent via ACP (Agent Client Protocol). It replaces OpenClaw with ~150 lines by delegating all agent complexity to acpx.
+acpella is a thin service that bridges a messaging channel (Telegram) to a coding agent via ACP (Agent Client Protocol). It keeps the messaging layer small while delegating agent behavior, tools, and memory to an ACP-compatible agent.
 
 ```
-Telegram  ──►  acpella  ──►  acpx  ──►  agent (Codex, Claude Code, ...)
-              (service)    (CLI)        (ACP subprocess)
+Telegram  ──►  acpella  ──►  ACP agent (Codex, Claude Code, ...)
+              (service)      (subprocess)
 ```
 
 **Why ACP**: ACP is the protocol Zed, Cursor, and other editors use to talk to coding agents. By speaking ACP, acpella is agent-agnostic — swap `ACPELLA_AGENT=codex` for `ACPELLA_AGENT=claude` without changing the service. The agent binary manages its own session state, tool execution, and memory.
 
-**Why acpx**: acpx is a standalone ACP client CLI. acpella shells out to it instead of speaking ACP directly, which keeps the service code minimal and offloads session management to acpx.
+**Why direct ACP**: acpella spawns the configured ACP agent and talks to it through the ACP TypeScript SDK. acpella owns Telegram session mapping and lightweight persistence, while the agent owns actual reasoning and tool execution.
 
 ## Components
 
@@ -19,7 +19,7 @@ Telegram  ──►  acpella  ──►  acpx  ──►  agent (Codex, Claude C
 
 Single-file service. Three sections:
 
-**acpx interface** — `ensureSession` and `acpxPrompt` shell out to `node_modules/.bin/acpx`. `acpxPrompt` runs `acpx ... prompt <text>` with `--format json`, capturing stdout as JSONRPC-envelope newline-delimited JSON, then extracts `agent_message_chunk` text to assemble the response.
+**ACP manager** — starts the configured agent subprocess, initializes ACP, creates or loads sessions, sends prompts, and extracts `agent_message_chunk` text to assemble the response.
 
 **Telegram** — grammy long-polling bot. One handler: `message:text`. Maps each chat/thread to a session name (`tg-<chatId>` or `tg-<chatId>-<threadId>`), calls `acpxPrompt`, replies with the result.
 
@@ -35,14 +35,16 @@ grammy bot handler
   │  checks allowlists (ACPELLA_TELEGRAM_ALLOWED_USER_IDS, ACPELLA_TELEGRAM_ALLOWED_CHAT_IDS)
   │  derives session name from chatId + threadId
   ▼
-acpxPrompt(sessionName, text)
+handler(sessionName, text)
   │
-  ├─► ensureSession → acpx sessions ensure
-  │     starts agent subprocess if not running
+  ├─► load existing session or create a new ACP session
   │
-  └─► acpx --format json <agent> prompt <text>
-        agent runs, streams JSONRPC lines to stdout
-        service collects agent_message_chunk lines → joins text
+  ├─► if new and ACPELLA_PROMPT_FILE is configured:
+  │     send initialization prompt
+  │
+  └─► send user prompt
+        agent streams session/update messages
+        service collects agent_message_chunk updates → joins text
   │
   ▼
 ctx.reply(response)
@@ -50,7 +52,7 @@ ctx.reply(response)
 
 ## Session model
 
-Each Telegram chat maps to one acpx session:
+Each Telegram chat maps to one ACP session:
 
 | Chat type    | Session name             |
 | ------------ | ------------------------ |
@@ -58,11 +60,13 @@ Each Telegram chat maps to one acpx session:
 | Group        | `tg-<chatId>`            |
 | Forum thread | `tg-<chatId>-<threadId>` |
 
-`ensureSession` is called before every prompt — acpx is idempotent if the session already exists. The agent process runs as a long-lived subprocess managed by acpx; acpella does not own its lifecycle.
+The session id is stored in `.acpella/state.json` under `ACPELLA_HOME`. `/session new` creates a
+fresh session for the current chat/thread. If `ACPELLA_PROMPT_FILE` is configured, the prompt file is
+sent once when a new session is created, including sessions created by `/session new`.
 
-## acpx output format
+## ACP updates
 
-`acpx --format json` emits newline-delimited JSONRPC 2.0 envelopes:
+The ACP agent emits `session/update` notifications:
 
 ```json
 {
@@ -78,12 +82,15 @@ Each Telegram chat maps to one acpx session:
 }
 ```
 
-acpella extracts text by filtering `params.update.sessionUpdate === "agent_message_chunk"` and joining `params.update.content.text` chunks.
+acpella extracts text by filtering updates where `sessionUpdate === "agent_message_chunk"` and
+joining `content.text` chunks.
 
 ## Key decisions
 
-**Single file** — the service is small enough that modules add indirection without benefit. Split when it grows.
+**Direct ACP subprocess** — avoids depending on a separate CLI for prompt dispatch while keeping the service agent-agnostic.
 
-**Shell out to acpx** — avoids owning the ACP client/session lifecycle. Tradeoff: subprocess overhead per prompt, no streaming to Telegram. Acceptable for a personal assistant.
+**No database** — session mapping lives in `.acpella/state.json`. Agent memory lives in the agent's working directory (`ACPELLA_HOME`). The service remains restartable.
 
-**No database** — session state lives in acpx. Memory lives in the agent's working directory (`ACPELLA_HOME`). The service is stateless and restartable.
+**Custom prompt file** — `ACPELLA_PROMPT_FILE` is sent as a normal ACP prompt turn when a session is
+created. Existing sessions are unchanged; restart acpella and run `/session new` to apply prompt file
+changes to a chat/thread.

--- a/docs/tasks/2026-04-12-custom-prompt.md
+++ b/docs/tasks/2026-04-12-custom-prompt.md
@@ -1,0 +1,192 @@
+# Custom Prompt
+
+## Problem Context
+
+acpella currently relies on the selected ACP agent to discover repo-local instructions such as
+`AGENTS.md`. That keeps acpella agent-agnostic, but it does not give the bridge owner a simple place
+to add personal or deployment-specific instructions that should apply to Telegram prompts.
+
+The goal is to support an acpella-level custom prompt in addition to agent-owned instruction
+discovery. This should not replace `AGENTS.md`, should not mutate repository files, and should not
+depend on Codex-only behavior.
+
+## Reference Files
+
+- `src/config.ts` owns config loading and is the only module that reads `process.env`.
+- `src/handler.ts` receives Telegram text, loads/creates an ACP session, and calls `session.prompt`.
+- `src/acp/index.ts` turns a text string into ACP `session/prompt` content blocks.
+- `docs/tasks/2026-04-12-config-mechanism.md` sketches the broader config-file direction.
+- `src/e2e/codex/basic.test.ts` verifies that Codex still discovers `AGENTS.md` from `home`.
+
+## ACP Constraints
+
+ACP `session/new` does not expose a portable system-prompt field. ACP `session/prompt` sends user
+content blocks. The `_meta` field is reserved for extensibility, but implementations must not depend
+on semantic behavior from `_meta`, so it is not a good fit for user-visible custom instructions.
+
+Because of that, the portable implementation is to send the custom prompt through ACP
+`session/prompt` as an initialization turn:
+
+```text
+<acpella_custom_instructions>
+...
+</acpella_custom_instructions>
+```
+
+## Approach
+
+- Treat custom prompt as an acpella user preference, not a higher-priority system instruction.
+- Use `ACPELLA_PROMPT_FILE` as the only MVP configuration surface.
+- Make the wording explicitly defer to higher-priority system, developer, repository, and security
+  instructions.
+- Keep repo instruction discovery untouched by continuing to pass `home` as the ACP session `cwd`.
+- Keep any Telegram command layer optional and separate from the first implementation.
+
+## Config Shape
+
+Environment-only MVP:
+
+```bash
+ACPELLA_PROMPT_FILE=/home/hiroshi/.config/acpella/prompt.md
+```
+
+When `ACPELLA_PROMPT_FILE` is unset, acpella sends Telegram text unchanged.
+
+When it is set, load the file once at startup. Fail fast if the file cannot be read, so a typo does
+not silently run the daemon without the expected instructions.
+
+Relative paths resolve against `home`, because it is the agent working directory and the place where
+related acpella state lives.
+
+## Prompt Injection Timing
+
+Decision: send the custom prompt once when creating a new session.
+
+### Option A: prepend every user turn
+
+Pros:
+
+- Works for new sessions and loaded sessions without knowing what prior context contains.
+- Agent-agnostic because it only uses ACP `session/prompt`.
+- Survives agent context compaction better because the instruction is always in the current turn.
+- Makes prompt file edits take effect on the next message after daemon restart.
+
+Cons:
+
+- Re-sends the same text every turn, increasing token use.
+- The instruction is user-message content, so it may be less authoritative than native agent
+  instructions.
+- Long custom prompts can crowd out the actual Telegram message on small-context agents.
+
+### Option B: send once when creating a new session
+
+Pros:
+
+- Lower token use after the first turn.
+- Keeps later Telegram messages cleaner.
+- More closely matches the user's mental model of an extra session instruction.
+
+Cons:
+
+- Loaded sessions may not have received the current prompt file.
+- Prompt changes apply only after creating a new session.
+- Still not a real system prompt; it is just an earlier user message.
+
+Mitigations:
+
+- Inject only immediately after `manager.newSession`, before saving the session as ready.
+- Use `/session new` as the explicit refresh path. A newly created session automatically receives the
+  currently loaded prompt file before the next user request.
+
+### Option C: agent-specific system prompt support
+
+Pros:
+
+- Potentially stronger instruction priority for agents that support it.
+- Avoids repeating the prompt in every user message.
+
+Cons:
+
+- Not portable ACP behavior.
+- Requires per-agent adapters and fallback behavior.
+- Risks hiding important behavior differences between Codex, Claude, and test agents.
+
+Chosen MVP: Option B. This avoids repeating the custom prompt on every Telegram message while
+remaining agent-agnostic. The tradeoff is that prompt changes apply cleanly only to newly created
+sessions.
+
+## Initialization Prompt Wrapper
+
+Recommended wrapper:
+
+```text
+Additional user preferences for this acpella bridge. Follow these unless they conflict with
+higher-priority system, developer, repository, or security instructions.
+
+<acpella_custom_instructions>
+{customPrompt}
+</acpella_custom_instructions>
+```
+
+Do not call it a system prompt in user-facing docs unless the implementation becomes agent-specific
+and actually uses an agent system-prompt mechanism.
+
+The wrapper can ask the agent to acknowledge the instruction tersely:
+
+```text
+Record these preferences for this session. Do not summarize them. Reply only with "OK".
+```
+
+The acknowledgement is returned as normal command output for `/session new`. For implicit session
+creation before the first user message, acpella runs the initialization turn first, then runs the
+user's message as the next turn.
+
+## Session Behavior
+
+When a new session is created and `ACPELLA_PROMPT_FILE` is configured, acpella should send the
+initialization prompt before marking the session ready. This applies both to implicit session
+creation on the first message and explicit `/session new`.
+
+Existing loaded sessions are left unchanged. If the prompt file changes, the operational workflow is:
+
+1. Restart acpella so the updated prompt file is loaded.
+2. Run `/session new` in the Telegram chat/thread that should use the new prompt.
+3. Continue chatting; the fresh session has already received the initialization prompt.
+
+No prompt hash or prompt-version state is needed for the MVP.
+
+## Implementation Plan
+
+1. Add prompt config to `AppConfig`, for example `prompt: { file?: string; text?: string }`.
+2. Add `ACPELLA_PROMPT_FILE` parsing in `src/config.ts`.
+3. Resolve `ACPELLA_PROMPT_FILE` relative to `home` and document the rule.
+4. Load the prompt file once at startup and fail fast if the configured file cannot be read.
+5. Add a helper such as `formatInitializationPrompt({ customPrompt })`.
+6. When `handlePrompt` creates a new session and a custom prompt is configured, send the
+   initialization prompt first.
+7. Update `/session new` so explicit new sessions also run the same initialization prompt flow.
+8. Persist the session id only after initialization succeeds.
+9. Keep loaded sessions unchanged.
+10. Keep `src/acp/index.ts` unchanged unless the prompt input needs to become structured later.
+11. Deferred: add unit tests for prompt formatting: no custom prompt, file prompt, empty prompt.
+12. Deferred: add an integration test with the test ACP agent to verify that new sessions receive the init
+    prompt before the user prompt, `/session new` initializes its fresh session, and loaded sessions
+    do not receive it again.
+13. Update `README.md` and `docs/architecture.md` with the new config option and session-new refresh
+    behavior.
+14. Run `pnpm lint` and `pnpm test`.
+
+## Later Iterations
+
+- Add `/prompt show` and `/prompt reload` Telegram commands.
+- Add per-chat or per-session prompt profiles if one deployment needs multiple personas.
+- Add config-file support once the broader config mechanism lands.
+- Consider agent-specific adapters only if a real agent exposes a stable system-prompt option and the
+  agent-agnostic fallback remains available.
+
+## Non-Goals
+
+- Do not write or modify `AGENTS.md` automatically.
+- Do not depend on ACP `_meta` for behavior.
+- Do not silently apply a changed prompt file to existing sessions.
+- Do not add Codex-only behavior to the common path.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,7 +16,6 @@ async function main() {
     strict: true,
   });
   const config = loadConfig();
-  const { handle } = await createHandler(config);
 
   // --- create bot (real or test) ---
 
@@ -47,6 +46,8 @@ async function main() {
 
   // --- wire handler (shared between real and test) ---
 
+  const handler = await createHandler(config);
+
   bot.on("message:text", async (ctx) => {
     const chatId = ctx.chat.id;
     const threadId = ctx.message.message_thread_id;
@@ -74,7 +75,7 @@ async function main() {
     }
 
     try {
-      const response = await handle(text, name);
+      const response = await handler.handle(text, name);
       if (!cli.repl) {
         console.log(`[${name}] -> ${response.slice(0, 100)}...`);
       }

--- a/src/config.ts
+++ b/src/config.ts
@@ -46,8 +46,8 @@ export function loadConfig(): AppConfig {
   const env = envSchema.parse(process.env);
   const home = env.ACPELLA_HOME ? path.resolve(env.ACPELLA_HOME) : process.cwd();
 
-  const agentName = env.ACPELLA_AGENT ?? "codex";
-  const agent = resolveAgent({ name: agentName });
+  const agentAlias = env.ACPELLA_AGENT ?? "codex";
+  const agentCommand = builtinAgents[agentAlias] || agentAlias;
 
   const promptFile = env.ACPELLA_PROMPT_FILE
     ? path.resolve(home, env.ACPELLA_PROMPT_FILE)
@@ -55,7 +55,7 @@ export function loadConfig(): AppConfig {
   const promptText = promptFile ? fs.readFileSync(promptFile, "utf8") : undefined;
 
   return {
-    agent,
+    agent: { alias: agentAlias, command: agentCommand },
     home,
     stateFile: path.join(home, ".acpella", "state.json"),
     telegram: {
@@ -70,15 +70,6 @@ export function loadConfig(): AppConfig {
     // TODO: make use of this for test
     testChatId: parseOptionalId(env.ACPELLA_TEST_CHAT_ID) ?? 10101010,
   };
-}
-
-function resolveAgent(options: { name: string }): AppConfig["agent"] {
-  const alias = options.name;
-  const knownAgent = builtinAgents[alias];
-  if (knownAgent) {
-    return { alias, command: knownAgent };
-  }
-  return { alias, command: alias };
 }
 
 function parseIdList(value: string | undefined): number[] | undefined {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import path from "node:path";
 import { z } from "zod";
 
@@ -12,6 +13,10 @@ export interface AppConfig {
     token?: string;
     allowedUserIds: number[];
     allowedChatIds: number[];
+  };
+  prompt: {
+    file?: string;
+    text?: string;
   };
   testChatId: number;
 }
@@ -29,6 +34,7 @@ const envSchema = z
   .object({
     ACPELLA_AGENT: z.string().optional(),
     ACPELLA_HOME: z.string().optional(),
+    ACPELLA_PROMPT_FILE: z.string().optional(),
     ACPELLA_TELEGRAM_BOT_TOKEN: z.string().optional(),
     ACPELLA_TELEGRAM_ALLOWED_USER_IDS: z.string().optional(),
     ACPELLA_TELEGRAM_ALLOWED_CHAT_IDS: z.string().optional(),
@@ -42,6 +48,7 @@ export function loadConfig(): AppConfig {
 
   const agentName = env.ACPELLA_AGENT ?? "codex";
   const agent = resolveAgent({ name: agentName });
+  const prompt = loadPromptConfig({ file: env.ACPELLA_PROMPT_FILE, home });
 
   return {
     agent,
@@ -52,6 +59,7 @@ export function loadConfig(): AppConfig {
       allowedUserIds: parseIdList(env.ACPELLA_TELEGRAM_ALLOWED_USER_IDS) ?? [],
       allowedChatIds: parseIdList(env.ACPELLA_TELEGRAM_ALLOWED_CHAT_IDS) ?? [],
     },
+    prompt,
     // TODO: make use of this for test
     testChatId: parseOptionalId(env.ACPELLA_TEST_CHAT_ID) ?? 10101010,
   };
@@ -91,4 +99,21 @@ function parseOptionalId(value: string | undefined): number | undefined {
     throw new Error(`Invalid numeric id: ${value}`);
   }
   return id;
+}
+
+function loadPromptConfig(options: {
+  file: string | undefined;
+  home: string;
+}): AppConfig["prompt"] {
+  if (options.file === undefined || options.file.trim() === "") {
+    return {};
+  }
+  const file = path.isAbsolute(options.file)
+    ? options.file
+    : path.resolve(options.home, options.file);
+  const text = fs.readFileSync(file, "utf8");
+  if (text.trim() === "") {
+    return { file };
+  }
+  return { file, text };
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -48,7 +48,8 @@ export function loadConfig(): AppConfig {
 
   const agentName = env.ACPELLA_AGENT ?? "codex";
   const agent = resolveAgent({ name: agentName });
-  const promptFile = env.ACPELLA_PROMPT_FILE?.trim()
+
+  const promptFile = env.ACPELLA_PROMPT_FILE
     ? path.resolve(home, env.ACPELLA_PROMPT_FILE)
     : undefined;
   const promptText = promptFile ? fs.readFileSync(promptFile, "utf8") : undefined;
@@ -64,7 +65,7 @@ export function loadConfig(): AppConfig {
     },
     prompt: {
       file: promptFile,
-      text: promptText?.trim() ? promptText : undefined,
+      text: promptText,
     },
     // TODO: make use of this for test
     testChatId: parseOptionalId(env.ACPELLA_TEST_CHAT_ID) ?? 10101010,

--- a/src/config.ts
+++ b/src/config.ts
@@ -48,7 +48,10 @@ export function loadConfig(): AppConfig {
 
   const agentName = env.ACPELLA_AGENT ?? "codex";
   const agent = resolveAgent({ name: agentName });
-  const prompt = loadPromptConfig({ file: env.ACPELLA_PROMPT_FILE, home });
+  const promptFile = env.ACPELLA_PROMPT_FILE?.trim()
+    ? path.resolve(home, env.ACPELLA_PROMPT_FILE)
+    : undefined;
+  const promptText = promptFile ? fs.readFileSync(promptFile, "utf8") : undefined;
 
   return {
     agent,
@@ -59,7 +62,10 @@ export function loadConfig(): AppConfig {
       allowedUserIds: parseIdList(env.ACPELLA_TELEGRAM_ALLOWED_USER_IDS) ?? [],
       allowedChatIds: parseIdList(env.ACPELLA_TELEGRAM_ALLOWED_CHAT_IDS) ?? [],
     },
-    prompt,
+    prompt: {
+      file: promptFile,
+      text: promptText?.trim() ? promptText : undefined,
+    },
     // TODO: make use of this for test
     testChatId: parseOptionalId(env.ACPELLA_TEST_CHAT_ID) ?? 10101010,
   };
@@ -99,21 +105,4 @@ function parseOptionalId(value: string | undefined): number | undefined {
     throw new Error(`Invalid numeric id: ${value}`);
   }
   return id;
-}
-
-function loadPromptConfig(options: {
-  file: string | undefined;
-  home: string;
-}): AppConfig["prompt"] {
-  if (options.file === undefined || options.file.trim() === "") {
-    return {};
-  }
-  const file = path.isAbsolute(options.file)
-    ? options.file
-    : path.resolve(options.home, options.file);
-  const text = fs.readFileSync(file, "utf8");
-  if (text.trim() === "") {
-    return { file };
-  }
-  return { file, text };
 }

--- a/src/e2e/codex/basic.test.ts
+++ b/src/e2e/codex/basic.test.ts
@@ -1,4 +1,3 @@
-import fs from "node:fs";
 import path from "node:path";
 import { it, vi } from "vitest";
 import { startService } from "../helper.ts";
@@ -8,17 +7,32 @@ vi.setConfig({
 });
 
 it("basic", async ({ onTestFinished }) => {
-  const service = startService({
-    ACPELLA_AGENT: "codex",
-  });
+  const service = startService(
+    {
+      ACPELLA_AGENT: "codex",
+    },
+    { sourceDir: path.join(import.meta.dirname, "fixtures/basic") },
+  );
   onTestFinished(async () => {
     await service.stop();
   });
-  fs.cpSync(
-    path.join(import.meta.dirname, "fixtures/basic/AGENTS.md"),
-    path.join(service.home, "AGENTS.md"),
-  );
   await service.waitForLine("Starting service");
   service.send("hello");
   await service.waitForLine("world");
+});
+
+it("uses custom prompt file", async ({ onTestFinished }) => {
+  const service = startService(
+    {
+      ACPELLA_AGENT: "codex",
+      ACPELLA_PROMPT_FILE: "custom-prompt.md",
+    },
+    { sourceDir: path.join(import.meta.dirname, "fixtures/custom-prompt") },
+  );
+  onTestFinished(async () => {
+    await service.stop();
+  });
+  await service.waitForLine("Starting service");
+  service.send("ping-custom-prompt");
+  await service.waitForLine("pong-custom-prompt");
 });

--- a/src/e2e/codex/fixtures/custom-prompt/custom-prompt.md
+++ b/src/e2e/codex/fixtures/custom-prompt/custom-prompt.md
@@ -1,0 +1,1 @@
+When receiving the message "ping-custom-prompt", respond with "pong-custom-prompt" exactly.

--- a/src/e2e/helper.ts
+++ b/src/e2e/helper.ts
@@ -7,9 +7,17 @@ import path from "node:path";
 const REPO_ROOT = path.join(import.meta.dirname, "../..");
 const TMP_ROOT = path.join(import.meta.dirname, ".tmp");
 
-export function startService(env?: Record<string, string>) {
+export function startService(
+  env?: Record<string, string>,
+  options?: {
+    sourceDir?: string;
+  },
+) {
   fs.mkdirSync(TMP_ROOT, { recursive: true });
   const home = fs.mkdtempSync(path.join(TMP_ROOT, "acpella-"));
+  if (options?.sourceDir) {
+    fs.cpSync(options.sourceDir, home, { recursive: true });
+  }
   const child = spawn("node", ["src/cli.ts", "--repl"], {
     cwd: REPO_ROOT,
     env: {

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -42,6 +42,7 @@ export async function createHandler(config: AppConfig): Promise<{
         : options.text;
 
     try {
+      // TODO: stream and split as needed
       const { queue } = session.prompt(promptText);
       const texts: string[] = [];
       for await (const update of queue) {

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -24,9 +24,6 @@ export async function createHandler(config: AppConfig): Promise<{
 }> {
   const manager = await startAcpManager({ command: config.agent.command, cwd: config.home });
   const state = createSessionStateStore(config);
-  const initializationPrompt = config.prompt.text
-    ? formatInitializationPrompt({ customPrompt: config.prompt.text })
-    : undefined;
 
   async function handlePrompt(name: string, text: string): Promise<string> {
     const persistedId = state.getSessionId(name);
@@ -39,17 +36,19 @@ export async function createHandler(config: AppConfig): Promise<{
       : await manager.newSession({ sessionCwd: config.home });
 
     try {
-      const responses: string[] = [];
-      if (isNewSession) {
-        responses.push(await initializeSession({ session, prompt: initializationPrompt }));
-      }
-
-      const response = await promptAndCollect({ session, text, logPrefix: "[acp:update]" });
-      responses.push(response);
+      const promptText =
+        isNewSession && config.prompt.text
+          ? formatFirstPrompt({ customPrompt: config.prompt.text, userText: text })
+          : text;
+      const response = await promptAndCollect({
+        session,
+        text: promptText,
+        logPrefix: "[acp:update]",
+      });
       if (isNewSession) {
         state.setSessionId(name, session.sessionId);
       }
-      return responses.filter(Boolean).join("\n\n") || "(no response)";
+      return response || "(no response)";
     } finally {
       session.close();
     }
@@ -73,9 +72,8 @@ export async function createHandler(config: AppConfig): Promise<{
   async function handleNewSession(name: string): Promise<string> {
     const session = await manager.newSession({ sessionCwd: config.home });
     try {
-      const response = await initializeSession({ session, prompt: initializationPrompt });
       state.setSessionId(name, session.sessionId);
-      return [`Created session: ${session.sessionId}`, response].filter(Boolean).join("\n\n");
+      return `Created session: ${session.sessionId}`;
     } finally {
       session.close();
     }
@@ -203,20 +201,6 @@ type HandlerSession = Awaited<
   ReturnType<Awaited<ReturnType<typeof startAcpManager>>["newSession"]>
 >;
 
-async function initializeSession(options: {
-  session: HandlerSession;
-  prompt: string | undefined;
-}): Promise<string> {
-  if (!options.prompt) {
-    return "";
-  }
-  return promptAndCollect({
-    session: options.session,
-    text: options.prompt,
-    logPrefix: "[acp:init]",
-  });
-}
-
 async function promptAndCollect(options: {
   session: HandlerSession;
   text: string;
@@ -236,15 +220,16 @@ async function promptAndCollect(options: {
   return texts.join("");
 }
 
-function formatInitializationPrompt(options: { customPrompt: string }): string {
+function formatFirstPrompt(options: { customPrompt: string; userText: string }): string {
   return [
     "Additional user preferences for this acpella bridge. Follow these unless they conflict with",
     "higher-priority system, developer, repository, or security instructions.",
     "",
-    'Record these preferences for this session. Do not summarize them. Reply only with "OK".',
-    "",
     "<acpella_custom_instructions>",
     options.customPrompt.trim(),
     "</acpella_custom_instructions>",
+    "",
+    "User request:",
+    options.userText,
   ].join("\n");
 }

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -8,17 +8,6 @@ interface StateSession {
   sessionId: string;
 }
 
-export function formatStatus(config: AppConfig): string {
-  return [
-    "service state: running",
-    `configured agent: ${config.agent.alias}`,
-    `agent command: ${config.agent.command}`,
-    `home: ${config.home}`,
-    `state file: ${config.stateFile}`,
-    `prompt file: ${config.prompt.file ?? "none"}`,
-  ].join("\n");
-}
-
 export async function createHandler(config: AppConfig): Promise<{
   handle: (text: string, session: string) => Promise<string>;
 }> {
@@ -165,9 +154,19 @@ export async function createHandler(config: AppConfig): Promise<{
     }
   }
 
+  function handleStatus(): string {
+    return `\
+service state: running
+configured agent: ${config.agent.alias}
+agent command: ${config.agent.command}
+home: ${config.home}
+state file: ${config.stateFile}
+prompt file: ${config.prompt.file ?? "none"}`;
+  }
+
   const handle = async (text: string, sessionName: string): Promise<string> => {
     if (text === "/status") {
-      return formatStatus(config);
+      return handleStatus();
     }
     const sessionCommandResponse = await handleSessionCommand(text, sessionName);
     if (sessionCommandResponse) {
@@ -208,15 +207,12 @@ function formatAgentSessions(response: Pick<ListSessionsResponse, "sessions">): 
 }
 
 function formatFirstPrompt(options: { customPrompt: string; userText: string }): string {
-  return [
-    "Additional user preferences for this acpella bridge. Follow these unless they conflict with",
-    "higher-priority system, developer, repository, or security instructions.",
-    "",
-    "<acpella_custom_instructions>",
-    options.customPrompt.trim(),
-    "</acpella_custom_instructions>",
-    "",
-    "User request:",
-    options.userText,
-  ].join("\n");
+  return `\
+Use these additional instructions for this session:
+
+<custom_instructions>
+${options.customPrompt.trim()}
+</custom_instructions>
+
+${options.userText}`;
 }

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -25,22 +25,21 @@ export async function createHandler(config: AppConfig): Promise<{
   const manager = await startAcpManager({ command: config.agent.command, cwd: config.home });
   const state = createSessionStateStore(config);
 
-  async function handlePrompt(name: string, text: string): Promise<string> {
-    const persistedId = state.getSessionId(name);
-    const isNewSession = !persistedId;
-    const session = persistedId
+  async function runPrompt(options: {
+    name: string;
+    text: string;
+    sessionId?: string;
+  }): Promise<{ sessionId: string; text: string }> {
+    const isNewSession = !options.sessionId;
+    const session = options.sessionId
       ? await manager.loadSession({
           sessionCwd: config.home,
-          sessionId: persistedId,
+          sessionId: options.sessionId,
         })
       : await manager.newSession({ sessionCwd: config.home });
 
     try {
-      const promptText =
-        isNewSession && config.prompt.text
-          ? formatFirstPrompt({ customPrompt: config.prompt.text, userText: text })
-          : text;
-      const { queue } = session.prompt(promptText);
+      const { queue } = session.prompt(options.text);
       const texts: string[] = [];
       for await (const update of queue) {
         if (update.sessionUpdate === "agent_message_chunk" && update.content.type === "text") {
@@ -52,12 +51,22 @@ export async function createHandler(config: AppConfig): Promise<{
         }
       }
       if (isNewSession) {
-        state.setSessionId(name, session.sessionId);
+        state.setSessionId(options.name, session.sessionId);
       }
-      return texts.join("") || "(no response)";
+      return { sessionId: session.sessionId, text: texts.join("") };
     } finally {
       session.close();
     }
+  }
+
+  async function handlePrompt(name: string, text: string): Promise<string> {
+    const sessionId = state.getSessionId(name);
+    const promptText =
+      !sessionId && config.prompt.text
+        ? formatFirstPrompt({ customPrompt: config.prompt.text, userText: text })
+        : text;
+    const result = await runPrompt({ name, text: promptText, sessionId });
+    return result.text || "(no response)";
   }
 
   async function handleCloseSession(name: string, sessionIdArg?: string): Promise<void> {
@@ -75,14 +84,15 @@ export async function createHandler(config: AppConfig): Promise<{
     }
   }
 
-  async function handleNewSession(name: string): Promise<string> {
-    const session = await manager.newSession({ sessionCwd: config.home });
-    try {
-      state.setSessionId(name, session.sessionId);
-      return `Created session: ${session.sessionId}`;
-    } finally {
-      session.close();
-    }
+  async function handleNewSession(name: string, text: string): Promise<string> {
+    const promptText = config.prompt.text
+      ? formatFirstPrompt({ customPrompt: config.prompt.text, userText: text })
+      : text;
+    const result = await runPrompt({
+      name,
+      text: promptText,
+    });
+    return [`Created session: ${result.sessionId}`, result.text || "(no response)"].join("\n\n");
   }
 
   async function handleLoadSession(name: string, sessionId: string | undefined): Promise<string> {
@@ -147,7 +157,7 @@ export async function createHandler(config: AppConfig): Promise<{
       case "list":
         return handleListSessions();
       case "new":
-        return handleNewSession(sessionName);
+        return handleNewSession(sessionName, args.join(" "));
       case "load":
         return handleLoadSession(sessionName, args[0]);
       case "close":

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -214,5 +214,6 @@ Use these additional instructions for this session:
 ${options.customPrompt.trim()}
 </custom_instructions>
 
-${options.userText}`;
+${options.userText}
+`;
 }

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -40,15 +40,21 @@ export async function createHandler(config: AppConfig): Promise<{
         isNewSession && config.prompt.text
           ? formatFirstPrompt({ customPrompt: config.prompt.text, userText: text })
           : text;
-      const response = await promptAndCollect({
-        session,
-        text: promptText,
-        logPrefix: "[acp:update]",
-      });
+      const { queue } = session.prompt(promptText);
+      const texts: string[] = [];
+      for await (const update of queue) {
+        if (update.sessionUpdate === "agent_message_chunk" && update.content.type === "text") {
+          texts.push(update.content.text);
+        } else if (update.sessionUpdate === "tool_call") {
+          console.log(`[acp:update] tool_call: ${update.title}`);
+        } else {
+          console.log(`[acp:update] ${update.sessionUpdate}`);
+        }
+      }
       if (isNewSession) {
         state.setSessionId(name, session.sessionId);
       }
-      return response || "(no response)";
+      return texts.join("") || "(no response)";
     } finally {
       session.close();
     }
@@ -195,29 +201,6 @@ function formatAgentSessions(response: Pick<ListSessionsResponse, "sessions">): 
       .filter(Boolean)
       .join(" "),
   );
-}
-
-type HandlerSession = Awaited<
-  ReturnType<Awaited<ReturnType<typeof startAcpManager>>["newSession"]>
->;
-
-async function promptAndCollect(options: {
-  session: HandlerSession;
-  text: string;
-  logPrefix: string;
-}): Promise<string> {
-  const { queue } = options.session.prompt(options.text);
-  const texts: string[] = [];
-  for await (const update of queue) {
-    if (update.sessionUpdate === "agent_message_chunk" && update.content.type === "text") {
-      texts.push(update.content.text);
-    } else if (update.sessionUpdate === "tool_call") {
-      console.log(`${options.logPrefix} tool_call: ${update.title}`);
-    } else {
-      console.log(`${options.logPrefix} ${update.sessionUpdate}`);
-    }
-  }
-  return texts.join("");
 }
 
 function formatFirstPrompt(options: { customPrompt: string; userText: string }): string {

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -25,21 +25,24 @@ export async function createHandler(config: AppConfig): Promise<{
   const manager = await startAcpManager({ command: config.agent.command, cwd: config.home });
   const state = createSessionStateStore(config);
 
-  async function runPrompt(options: {
+  async function handlePrompt(options: {
     name: string;
     text: string;
     sessionId?: string;
-  }): Promise<{ sessionId: string; text: string }> {
-    const isNewSession = !options.sessionId;
+  }): Promise<string> {
     const session = options.sessionId
       ? await manager.loadSession({
           sessionCwd: config.home,
           sessionId: options.sessionId,
         })
       : await manager.newSession({ sessionCwd: config.home });
+    const promptText =
+      !options.sessionId && config.prompt.text
+        ? formatFirstPrompt({ customPrompt: config.prompt.text, userText: options.text })
+        : options.text;
 
     try {
-      const { queue } = session.prompt(options.text);
+      const { queue } = session.prompt(promptText);
       const texts: string[] = [];
       for await (const update of queue) {
         if (update.sessionUpdate === "agent_message_chunk" && update.content.type === "text") {
@@ -50,23 +53,13 @@ export async function createHandler(config: AppConfig): Promise<{
           console.log(`[acp:update] ${update.sessionUpdate}`);
         }
       }
-      if (isNewSession) {
+      if (!options.sessionId) {
         state.setSessionId(options.name, session.sessionId);
       }
-      return { sessionId: session.sessionId, text: texts.join("") };
+      return texts.join("") || "(no response)";
     } finally {
       session.close();
     }
-  }
-
-  async function handlePrompt(name: string, text: string): Promise<string> {
-    const sessionId = state.getSessionId(name);
-    const promptText =
-      !sessionId && config.prompt.text
-        ? formatFirstPrompt({ customPrompt: config.prompt.text, userText: text })
-        : text;
-    const result = await runPrompt({ name, text: promptText, sessionId });
-    return result.text || "(no response)";
   }
 
   async function handleCloseSession(name: string, sessionIdArg?: string): Promise<void> {
@@ -85,14 +78,10 @@ export async function createHandler(config: AppConfig): Promise<{
   }
 
   async function handleNewSession(name: string, text: string): Promise<string> {
-    const promptText = config.prompt.text
-      ? formatFirstPrompt({ customPrompt: config.prompt.text, userText: text })
-      : text;
-    const result = await runPrompt({
+    return handlePrompt({
       name,
-      text: promptText,
+      text,
     });
-    return result.text || "(no response)";
   }
 
   async function handleLoadSession(name: string, sessionId: string | undefined): Promise<string> {
@@ -184,7 +173,11 @@ export async function createHandler(config: AppConfig): Promise<{
       return sessionCommandResponse;
     }
 
-    return handlePrompt(sessionName, text);
+    return handlePrompt({
+      name: sessionName,
+      text,
+      sessionId: state.getSessionId(sessionName),
+    });
   };
 
   return { handle };

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -15,6 +15,7 @@ export function formatStatus(config: AppConfig): string {
     `agent command: ${config.agent.command}`,
     `home: ${config.home}`,
     `state file: ${config.stateFile}`,
+    `prompt file: ${config.prompt.file ?? "none"}`,
   ].join("\n");
 }
 
@@ -23,6 +24,9 @@ export async function createHandler(config: AppConfig): Promise<{
 }> {
   const manager = await startAcpManager({ command: config.agent.command, cwd: config.home });
   const state = createSessionStateStore(config);
+  const initializationPrompt = config.prompt.text
+    ? formatInitializationPrompt({ customPrompt: config.prompt.text })
+    : undefined;
 
   async function handlePrompt(name: string, text: string): Promise<string> {
     const persistedId = state.getSessionId(name);
@@ -35,23 +39,17 @@ export async function createHandler(config: AppConfig): Promise<{
       : await manager.newSession({ sessionCwd: config.home });
 
     try {
-      const { queue } = session.prompt(text);
-
-      // TODO: stream and split as needed
-      const texts: string[] = [];
-      for await (const update of queue) {
-        if (update.sessionUpdate === "agent_message_chunk" && update.content.type === "text") {
-          texts.push(update.content.text);
-        } else if (update.sessionUpdate === "tool_call") {
-          console.log(`[acp:update] tool_call: ${update.title}`);
-        } else {
-          console.log(`[acp:update] ${update.sessionUpdate}`);
-        }
+      const responses: string[] = [];
+      if (isNewSession) {
+        responses.push(await initializeSession({ session, prompt: initializationPrompt }));
       }
+
+      const response = await promptAndCollect({ session, text, logPrefix: "[acp:update]" });
+      responses.push(response);
       if (isNewSession) {
         state.setSessionId(name, session.sessionId);
       }
-      return texts.join("") || "(no response)";
+      return responses.filter(Boolean).join("\n\n") || "(no response)";
     } finally {
       session.close();
     }
@@ -75,8 +73,9 @@ export async function createHandler(config: AppConfig): Promise<{
   async function handleNewSession(name: string): Promise<string> {
     const session = await manager.newSession({ sessionCwd: config.home });
     try {
+      const response = await initializeSession({ session, prompt: initializationPrompt });
       state.setSessionId(name, session.sessionId);
-      return `Created session: ${session.sessionId}`;
+      return [`Created session: ${session.sessionId}`, response].filter(Boolean).join("\n\n");
     } finally {
       session.close();
     }
@@ -198,4 +197,54 @@ function formatAgentSessions(response: Pick<ListSessionsResponse, "sessions">): 
       .filter(Boolean)
       .join(" "),
   );
+}
+
+type HandlerSession = Awaited<
+  ReturnType<Awaited<ReturnType<typeof startAcpManager>>["newSession"]>
+>;
+
+async function initializeSession(options: {
+  session: HandlerSession;
+  prompt: string | undefined;
+}): Promise<string> {
+  if (!options.prompt) {
+    return "";
+  }
+  return promptAndCollect({
+    session: options.session,
+    text: options.prompt,
+    logPrefix: "[acp:init]",
+  });
+}
+
+async function promptAndCollect(options: {
+  session: HandlerSession;
+  text: string;
+  logPrefix: string;
+}): Promise<string> {
+  const { queue } = options.session.prompt(options.text);
+  const texts: string[] = [];
+  for await (const update of queue) {
+    if (update.sessionUpdate === "agent_message_chunk" && update.content.type === "text") {
+      texts.push(update.content.text);
+    } else if (update.sessionUpdate === "tool_call") {
+      console.log(`${options.logPrefix} tool_call: ${update.title}`);
+    } else {
+      console.log(`${options.logPrefix} ${update.sessionUpdate}`);
+    }
+  }
+  return texts.join("");
+}
+
+function formatInitializationPrompt(options: { customPrompt: string }): string {
+  return [
+    "Additional user preferences for this acpella bridge. Follow these unless they conflict with",
+    "higher-priority system, developer, repository, or security instructions.",
+    "",
+    'Record these preferences for this session. Do not summarize them. Reply only with "OK".',
+    "",
+    "<acpella_custom_instructions>",
+    options.customPrompt.trim(),
+    "</acpella_custom_instructions>",
+  ].join("\n");
 }

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -92,7 +92,7 @@ export async function createHandler(config: AppConfig): Promise<{
       name,
       text: promptText,
     });
-    return [`Created session: ${result.sessionId}`, result.text || "(no response)"].join("\n\n");
+    return result.text || "(no response)";
   }
 
   async function handleLoadSession(name: string, sessionId: string | undefined): Promise<string> {


### PR DESCRIPTION
## Summary
- add ACPELLA_PROMPT_FILE config loading relative to ACPELLA_HOME
- send the configured prompt once when creating a new ACP session
- document the prompt-file workflow and task plan

## Verification
- pnpm exec tsc --noEmit

Tests were not added or run per request.