### PR TITLE
feat: split and stream response

### DIFF
--- a/docs/prd.md
+++ b/docs/prd.md
@@ -8,21 +8,20 @@
   - [ ] Typing indicator while agent is working
     - Keep sending Telegram chat action during long gaps where no text/tool updates are flushed
   - [ ] Markdown formatting (Telegram MarkdownV2)
-  - [ ] Long message splitting (Telegram 4096 char limit)
+  - [x] Long message splitting (Telegram 4096 char limit)
 - [ ] feat: session lifecycle
   - [ ] Daily refresh — close and recreate session at configurable hour
   - [ ] Session-per-thread — verify acpx handles named sessions correctly
 - [x] fix: Named acpx session not working — was arg placement: `-s` is a `prompt` subcommand option, not `codex`
-- [ ] feat: system prompt (just use AGENTS.md convention)
-- [ ] feat: system commands
+- [x] feat: system prompt (just use AGENTS.md convention)
+- [x] feat: system commands
   - [x] status
   - [x] session current/list/new/load/close
 - [ ] refactor: env config util
 - [ ] refactor: child process exec util
   - [x] debug log
 - [ ] perf: warmed agent process/session cache
-- [ ] chore: dog-fooding
-  - In-flight message can be dropped when `pnpm dev` auto-restarts during processing
+- [x] chore: dog-fooding
 - [x] test: test repl mode with toy acp
 - [x] test: test repl mode with codex
 - [ ] fix: handle timeout — reply with error if acpx doesn't respond in 5 min
@@ -35,7 +34,7 @@
   - Target session — cron jobs specify which session
   - Run log — log each execution result
 - [ ] feat: heartbeat
-- [ ] feat: make session selectable on repl mode
+- [x] feat: make session selectable on repl mode
 
 ## Backlog
 

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -1,15 +1,5 @@
 # TODO
 
-- [x] chore: replace "daemon" with "service"
-- [x] fix: Named acpx session not working — was arg placement: `-s` is a `prompt` subcommand option, not `codex`
-- [x] feat: system prompt (just use AGENTS.md convention)
-- [x] feat: system commands
-  - [x] status
-  - [x] session current/list/new/load/close
-- [x] chore: dog-fooding
-- [x] test: test repl mode with toy acp
-- [x] test: test repl mode with codex
-- [x] feat: make session selectable on repl mode
 - [ ] feat: telegram integration
   - [x] Receive text messages, reply with agent response
   - [x] Sender allowlist (user + chat)
@@ -21,9 +11,6 @@
 - [ ] feat: session lifecycle
   - [ ] Daily refresh — close and recreate session at configurable hour
   - [ ] Session-per-thread — verify acpx handles named sessions correctly
-- [ ] refactor: env config util
-- [ ] refactor: child process exec util
-  - [x] debug log
 - [ ] perf: warmed agent process/session cache
 - [ ] fix: handle timeout — reply with error if acpx doesn't respond in 5 min
   - Important for streaming because a partially delivered response can otherwise hang without a terminal message
@@ -35,6 +22,7 @@
   - Target session — cron jobs specify which session
   - Run log — log each execution result
 - [ ] feat: heartbeat
+- [ ] test: rework startService helper
 
 ## Backlog
 

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -6,6 +6,7 @@
   - [x] Sender allowlist (user + chat)
   - [ ] Chat/thread → named session mapping
   - [ ] Typing indicator while agent is working
+    - Keep sending Telegram chat action during long gaps where no text/tool updates are flushed
   - [ ] Markdown formatting (Telegram MarkdownV2)
   - [ ] Long message splitting (Telegram 4096 char limit)
 - [ ] feat: session lifecycle
@@ -25,7 +26,9 @@
 - [x] test: test repl mode with toy acp
 - [x] test: test repl mode with codex
 - [ ] fix: handle timeout — reply with error if acpx doesn't respond in 5 min
+  - Important for streaming because a partially delivered response can otherwise hang without a terminal message
 - [ ] fix: queue — if message arrives while one is processing, queue it
+  - Required before streaming responses can be considered robust; concurrent prompts in the same session must not interleave replies
 - [ ] feat: cron
   - Config file with scheduled prompts (JSON or YAML)
   - Poll loop — check schedule every 60s, fire due prompts into sessions

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -1,29 +1,30 @@
 # TODO
 
 - [x] chore: replace "daemon" with "service"
-- [ ] feat: telegram integration
-  - [x] Receive text messages, reply with agent response
-  - [x] Sender allowlist (user + chat)
-  - [ ] Chat/thread → named session mapping
-  - [ ] Typing indicator while agent is working
-    - Keep sending Telegram chat action during long gaps where no text/tool updates are flushed
-  - [ ] Markdown formatting (Telegram MarkdownV2)
-  - [x] Long message splitting (Telegram 4096 char limit)
-- [ ] feat: session lifecycle
-  - [ ] Daily refresh — close and recreate session at configurable hour
-  - [ ] Session-per-thread — verify acpx handles named sessions correctly
 - [x] fix: Named acpx session not working — was arg placement: `-s` is a `prompt` subcommand option, not `codex`
 - [x] feat: system prompt (just use AGENTS.md convention)
 - [x] feat: system commands
   - [x] status
   - [x] session current/list/new/load/close
+- [x] chore: dog-fooding
+- [x] test: test repl mode with toy acp
+- [x] test: test repl mode with codex
+- [x] feat: make session selectable on repl mode
+- [ ] feat: telegram integration
+  - [x] Receive text messages, reply with agent response
+  - [x] Sender allowlist (user + chat)
+  - [x] Long message splitting (Telegram 4096 char limit)
+  - [ ] Chat/thread → named session mapping
+  - [ ] Typing indicator while agent is working
+    - Keep sending Telegram chat action during long gaps where no text/tool updates are flushed
+  - [ ] Markdown formatting (Telegram MarkdownV2)
+- [ ] feat: session lifecycle
+  - [ ] Daily refresh — close and recreate session at configurable hour
+  - [ ] Session-per-thread — verify acpx handles named sessions correctly
 - [ ] refactor: env config util
 - [ ] refactor: child process exec util
   - [x] debug log
 - [ ] perf: warmed agent process/session cache
-- [x] chore: dog-fooding
-- [x] test: test repl mode with toy acp
-- [x] test: test repl mode with codex
 - [ ] fix: handle timeout — reply with error if acpx doesn't respond in 5 min
   - Important for streaming because a partially delivered response can otherwise hang without a terminal message
 - [ ] fix: queue — if message arrives while one is processing, queue it
@@ -34,7 +35,6 @@
   - Target session — cron jobs specify which session
   - Run log — log each execution result
 - [ ] feat: heartbeat
-- [x] feat: make session selectable on repl mode
 
 ## Backlog
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -103,11 +103,10 @@ Options:
     }
 
     try {
-      const response = await handler.handle(text, name);
+      await handler.handle({ session: name, context: ctx });
       if (!cli.repl) {
-        console.log(`[${name}] -> ${response.slice(0, 100)}...`);
+        console.log(`[${name}] -> response sent`);
       }
-      await ctx.reply(response);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       console.error(`[${name}] error: ${msg}`);

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -133,11 +133,10 @@ export async function createHandler(config: AppConfig): Promise<{
   }
 
   function handleCurrentSession(options: { name: string }): string {
-    return [
-      `session: ${options.name}`,
-      `agent: ${config.agent.alias}`,
-      `session id: ${state.getSessionId(options.name) ?? "none"}`,
-    ].join("\n");
+    return `\
+session: ${options.name}
+agent: ${config.agent.alias}
+session id: ${state.getSessionId(options.name) ?? "none"}`;
   }
 
   async function handleListSessions(): Promise<string> {
@@ -152,19 +151,18 @@ export async function createHandler(config: AppConfig): Promise<{
       (session) => !stateSessionIds.has(session.sessionId),
     );
 
-    return [
-      `state sessions (${stateSessions.length}):`,
-      ...formatStateSessions(stateSessions),
-      "",
-      `agent sessions (${agentSessions.sessions.length}):`,
-      ...formatAgentSessions(agentSessions),
-      "",
-      `state missing in agent (${missingInAgent.length}):`,
-      ...formatStateSessions(missingInAgent),
-      "",
-      `agent not tracked by state (${untrackedAgentSessions.length}):`,
-      ...formatAgentSessions({ sessions: untrackedAgentSessions }),
-    ].join("\n");
+    return `\
+state sessions (${stateSessions.length}):
+${formatStateSessions(stateSessions).join("\n")}
+
+agent sessions (${agentSessions.sessions.length}):
+${formatAgentSessions(agentSessions).join("\n")}
+
+state missing in agent (${missingInAgent.length}):
+${formatStateSessions(missingInAgent).join("\n")}
+
+agent not tracked by state (${untrackedAgentSessions.length}):
+${formatAgentSessions({ sessions: untrackedAgentSessions }).join("\n")}`;
   }
 
   async function handleSessionCommand(options: {
@@ -205,14 +203,13 @@ export async function createHandler(config: AppConfig): Promise<{
         response = "Session closed. Next message will start a fresh session.";
         break;
       default:
-        response = [
-          "Usage:",
-          "/session",
-          "/session list",
-          "/session new",
-          "/session load <sessionId>",
-          "/session close [sessionId]",
-        ].join("\n");
+        response = `\
+Usage:
+/session
+/session list
+/session new
+/session load <sessionId>
+/session close [sessionId]`;
     }
     await sendTextResponse(options.context, response);
     return true;

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -86,9 +86,12 @@ export async function createHandler(config: AppConfig): Promise<{
     }
   }
 
-  async function handleCloseSession(name: string, sessionIdArg?: string): Promise<void> {
-    const currentSessionId = state.getSessionId(name);
-    const sessionId = sessionIdArg ?? currentSessionId;
+  async function handleCloseSession(options: {
+    name: string;
+    sessionIdArg?: string;
+  }): Promise<void> {
+    const currentSessionId = state.getSessionId(options.name);
+    const sessionId = options.sessionIdArg ?? currentSessionId;
     if (sessionId) {
       try {
         await manager.closeSession({ sessionId });
@@ -96,37 +99,44 @@ export async function createHandler(config: AppConfig): Promise<{
         console.error("[acp] closeSession failed:", e);
       }
     }
-    if (!sessionIdArg || sessionIdArg === currentSessionId) {
-      state.deleteSession(name);
+    if (!options.sessionIdArg || options.sessionIdArg === currentSessionId) {
+      state.deleteSession(options.name);
     }
   }
 
-  async function handleNewSession(context: Context, name: string, text: string): Promise<void> {
+  async function handleNewSession(options: {
+    context: Context;
+    name: string;
+    text: string;
+  }): Promise<void> {
     return handlePrompt({
-      context,
-      name,
-      text,
+      context: options.context,
+      name: options.name,
+      text: options.text,
     });
   }
 
-  async function handleLoadSession(name: string, sessionId: string | undefined): Promise<string> {
-    if (!sessionId) {
+  async function handleLoadSession(options: { name: string; sessionId?: string }): Promise<string> {
+    if (!options.sessionId) {
       return "Usage: /session load <sessionId>";
     }
-    const session = await manager.loadSession({ sessionCwd: config.home, sessionId });
+    const session = await manager.loadSession({
+      sessionCwd: config.home,
+      sessionId: options.sessionId,
+    });
     try {
-      state.setSessionId(name, session.sessionId);
+      state.setSessionId(options.name, session.sessionId);
       return `Loaded session: ${session.sessionId}`;
     } finally {
       session.close();
     }
   }
 
-  function handleCurrentSession(name: string): string {
+  function handleCurrentSession(options: { name: string }): string {
     return [
-      `session: ${name}`,
+      `session: ${options.name}`,
       `agent: ${config.agent.alias}`,
-      `session id: ${state.getSessionId(name) ?? "none"}`,
+      `session id: ${state.getSessionId(options.name) ?? "none"}`,
     ].join("\n");
   }
 
@@ -157,31 +167,41 @@ export async function createHandler(config: AppConfig): Promise<{
     ].join("\n");
   }
 
-  async function handleSessionCommand(
-    context: Context,
-    text: string,
-    sessionName: string,
-  ): Promise<boolean> {
-    const [command, subcommand, ...args] = text.trim().split(/\s+/);
+  async function handleSessionCommand(options: {
+    context: Context;
+    text: string;
+    sessionName: string;
+  }): Promise<boolean> {
+    const [command, subcommand, ...args] = options.text.trim().split(/\s+/);
     if (command !== "/session") {
       return false;
     }
     let response: string;
     switch (subcommand) {
       case undefined:
-        response = handleCurrentSession(sessionName);
+        response = handleCurrentSession({ name: options.sessionName });
         break;
       case "list":
         response = await handleListSessions();
         break;
       case "new":
-        await handleNewSession(context, sessionName, args.join(" "));
+        await handleNewSession({
+          context: options.context,
+          name: options.sessionName,
+          text: args.join(" "),
+        });
         return true;
       case "load":
-        response = await handleLoadSession(sessionName, args[0]);
+        response = await handleLoadSession({
+          name: options.sessionName,
+          sessionId: args[0],
+        });
         break;
       case "close":
-        await handleCloseSession(sessionName, args[0]);
+        await handleCloseSession({
+          name: options.sessionName,
+          sessionIdArg: args[0],
+        });
         response = "Session closed. Next message will start a fresh session.";
         break;
       default:
@@ -194,7 +214,7 @@ export async function createHandler(config: AppConfig): Promise<{
           "/session close [sessionId]",
         ].join("\n");
     }
-    await sendTextResponse(context, response);
+    await sendTextResponse(options.context, response);
     return true;
   }
 
@@ -216,7 +236,11 @@ prompt file: ${config.prompt.file ?? "none"}`;
       await sendTextResponse(options.context, handleStatus());
       return;
     }
-    const handledSessionCommand = await handleSessionCommand(options.context, text, sessionName);
+    const handledSessionCommand = await handleSessionCommand({
+      context: options.context,
+      text,
+      sessionName,
+    });
     if (handledSessionCommand) {
       return;
     }

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -43,11 +43,11 @@ export async function createHandler(config: AppConfig): Promise<{
 
       for await (const update of queue) {
         if (update.sessionUpdate === "agent_message_chunk" && update.content.type === "text") {
-          await responseWriter.appendText(update.content.text);
+          await responseWriter.write(update.content.text);
         } else if (update.sessionUpdate === "tool_call") {
           console.log(`[acp:update] tool_call: ${update.title}`);
           await responseWriter.flush();
-          await responseWriter.write(`Tool: ${update.title}`);
+          await responseWriter.write(`Tool: ${update.title}`, { force: true });
         } else {
           console.log(`[acp:update] ${update.sessionUpdate}`);
         }
@@ -319,7 +319,7 @@ function createResponseWriter(options: { context: Context; limit: number }) {
   let bufferedText = "";
   let sentResponse = false;
 
-  async function write(text: string): Promise<void> {
+  async function send(text: string): Promise<void> {
     await sendTextResponse({
       context: options.context,
       limit: options.limit,
@@ -333,7 +333,7 @@ function createResponseWriter(options: { context: Context; limit: number }) {
       bufferedText = "";
       return;
     }
-    await write(bufferedText);
+    await send(bufferedText);
     bufferedText = "";
   }
 
@@ -343,18 +343,21 @@ function createResponseWriter(options: { context: Context; limit: number }) {
       const part = bufferedText.slice(0, splitIndex).trim();
       bufferedText = bufferedText.slice(splitIndex);
       if (part) {
-        await write(part);
+        await send(part);
       }
     }
   }
 
   return {
-    async appendText(text: string): Promise<void> {
+    async write(text: string, writeOptions?: { force?: boolean }): Promise<void> {
+      if (writeOptions?.force) {
+        await send(text);
+        return;
+      }
       bufferedText += text;
       await flushOversizedText();
     },
     flush,
-    write,
     async finish(): Promise<void> {
       await flush();
       if (!sentResponse) {

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -46,7 +46,13 @@ export async function createHandler(config: AppConfig): Promise<{
           await responseWriter.appendText(update.content.text);
         } else if (update.sessionUpdate === "tool_call") {
           console.log(`[acp:update] tool_call: ${update.title}`);
-          await responseWriter.sendToolCall(update.title);
+          await responseWriter.flush();
+          await sendTextResponse({
+            context: options.context,
+            limit: MESSAGE_SPLIT_BUDGET,
+            text: `Tool: ${update.title}`,
+          });
+          responseWriter.markSent();
         } else {
           console.log(`[acp:update] ${update.sessionUpdate}`);
         }
@@ -318,7 +324,7 @@ function createResponseWriter(options: { context: Context; limit: number }) {
   let bufferedText = "";
   let sentResponse = false;
 
-  async function flushText(): Promise<void> {
+  async function flush(): Promise<void> {
     if (!bufferedText.trim()) {
       bufferedText = "";
       return;
@@ -353,17 +359,12 @@ function createResponseWriter(options: { context: Context; limit: number }) {
       bufferedText += text;
       await flushOversizedText();
     },
-    async sendToolCall(title: string): Promise<void> {
-      await flushText();
-      await sendTextResponse({
-        context: options.context,
-        limit: options.limit,
-        text: `Tool: ${title}`,
-      });
+    flush,
+    markSent(): void {
       sentResponse = true;
     },
     async finish(): Promise<void> {
-      await flushText();
+      await flush();
       if (!sentResponse) {
         await options.context.reply("(no response)");
       }

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -47,12 +47,7 @@ export async function createHandler(config: AppConfig): Promise<{
         } else if (update.sessionUpdate === "tool_call") {
           console.log(`[acp:update] tool_call: ${update.title}`);
           await responseWriter.flush();
-          await sendTextResponse({
-            context: options.context,
-            limit: MESSAGE_SPLIT_BUDGET,
-            text: `Tool: ${update.title}`,
-          });
-          responseWriter.markSent();
+          await responseWriter.write(`Tool: ${update.title}`);
         } else {
           console.log(`[acp:update] ${update.sessionUpdate}`);
         }
@@ -324,17 +319,21 @@ function createResponseWriter(options: { context: Context; limit: number }) {
   let bufferedText = "";
   let sentResponse = false;
 
+  async function write(text: string): Promise<void> {
+    await sendTextResponse({
+      context: options.context,
+      limit: options.limit,
+      text,
+    });
+    sentResponse = true;
+  }
+
   async function flush(): Promise<void> {
     if (!bufferedText.trim()) {
       bufferedText = "";
       return;
     }
-    await sendTextResponse({
-      context: options.context,
-      limit: options.limit,
-      text: bufferedText,
-    });
-    sentResponse = true;
+    await write(bufferedText);
     bufferedText = "";
   }
 
@@ -344,12 +343,7 @@ function createResponseWriter(options: { context: Context; limit: number }) {
       const part = bufferedText.slice(0, splitIndex).trim();
       bufferedText = bufferedText.slice(splitIndex);
       if (part) {
-        await sendTextResponse({
-          context: options.context,
-          limit: options.limit,
-          text: part,
-        });
-        sentResponse = true;
+        await write(part);
       }
     }
   }
@@ -360,9 +354,7 @@ function createResponseWriter(options: { context: Context; limit: number }) {
       await flushOversizedText();
     },
     flush,
-    markSent(): void {
-      sentResponse = true;
-    },
+    write,
     async finish(): Promise<void> {
       await flush();
       if (!sentResponse) {

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -47,7 +47,8 @@ export async function createHandler(config: AppConfig): Promise<{
         } else if (update.sessionUpdate === "tool_call") {
           console.log(`[acp:update] tool_call: ${update.title}`);
           await responseWriter.flush();
-          await responseWriter.write(`Tool: ${update.title}`, { force: true });
+          await responseWriter.write(`Tool: ${update.title}`);
+          await responseWriter.flush();
         } else {
           console.log(`[acp:update] ${update.sessionUpdate}`);
         }
@@ -349,11 +350,7 @@ function createResponseWriter(options: { context: Context; limit: number }) {
   }
 
   return {
-    async write(text: string, writeOptions?: { force?: boolean }): Promise<void> {
-      if (writeOptions?.force) {
-        await send(text);
-        return;
-      }
+    async write(text: string): Promise<void> {
       bufferedText += text;
       await flushOversizedText();
     },

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -1,7 +1,10 @@
 import type { ListSessionsResponse } from "@agentclientprotocol/sdk";
+import type { Context } from "grammy";
 import { startAcpManager } from "./acp/index.ts";
 import type { AppConfig } from "./config.ts";
 import { createSessionStateStore } from "./state.ts";
+
+const MESSAGE_SPLIT_BUDGET = 3900;
 
 interface StateSession {
   name: string;
@@ -9,16 +12,17 @@ interface StateSession {
 }
 
 export async function createHandler(config: AppConfig): Promise<{
-  handle: (text: string, session: string) => Promise<string>;
+  handle: (options: { session: string; context: Context }) => Promise<void>;
 }> {
   const manager = await startAcpManager({ command: config.agent.command, cwd: config.home });
   const state = createSessionStateStore(config);
 
   async function handlePrompt(options: {
+    context: Context;
     name: string;
     text: string;
     sessionId?: string;
-  }): Promise<string> {
+  }): Promise<void> {
     const session = options.sessionId
       ? await manager.loadSession({
           sessionCwd: config.home,
@@ -31,22 +35,52 @@ export async function createHandler(config: AppConfig): Promise<{
         : options.text;
 
     try {
-      // TODO: stream and split as needed
       const { queue } = session.prompt(promptText);
-      const texts: string[] = [];
+      let bufferedText = "";
+      let sentResponse = false;
+
+      async function flushBufferedText(): Promise<void> {
+        if (!bufferedText.trim()) {
+          bufferedText = "";
+          return;
+        }
+        await sendTextResponse(options.context, bufferedText);
+        sentResponse = true;
+        bufferedText = "";
+      }
+
+      async function flushOversizedText(): Promise<void> {
+        while (bufferedText.length > MESSAGE_SPLIT_BUDGET) {
+          const splitIndex = findSplitIndex(bufferedText, MESSAGE_SPLIT_BUDGET);
+          const part = bufferedText.slice(0, splitIndex).trim();
+          bufferedText = bufferedText.slice(splitIndex);
+          if (part) {
+            await options.context.reply(part);
+            sentResponse = true;
+          }
+        }
+      }
+
       for await (const update of queue) {
         if (update.sessionUpdate === "agent_message_chunk" && update.content.type === "text") {
-          texts.push(update.content.text);
+          bufferedText += update.content.text;
+          await flushOversizedText();
         } else if (update.sessionUpdate === "tool_call") {
           console.log(`[acp:update] tool_call: ${update.title}`);
+          await flushBufferedText();
+          await sendTextResponse(options.context, `Tool: ${update.title}`);
+          sentResponse = true;
         } else {
           console.log(`[acp:update] ${update.sessionUpdate}`);
         }
       }
+      await flushBufferedText();
       if (!options.sessionId) {
         state.setSessionId(options.name, session.sessionId);
       }
-      return texts.join("") || "(no response)";
+      if (!sentResponse) {
+        await options.context.reply("(no response)");
+      }
     } finally {
       session.close();
     }
@@ -67,8 +101,9 @@ export async function createHandler(config: AppConfig): Promise<{
     }
   }
 
-  async function handleNewSession(name: string, text: string): Promise<string> {
+  async function handleNewSession(context: Context, name: string, text: string): Promise<void> {
     return handlePrompt({
+      context,
       name,
       text,
     });
@@ -123,27 +158,34 @@ export async function createHandler(config: AppConfig): Promise<{
   }
 
   async function handleSessionCommand(
+    context: Context,
     text: string,
     sessionName: string,
-  ): Promise<string | undefined> {
+  ): Promise<boolean> {
     const [command, subcommand, ...args] = text.trim().split(/\s+/);
     if (command !== "/session") {
-      return undefined;
+      return false;
     }
+    let response: string;
     switch (subcommand) {
       case undefined:
-        return handleCurrentSession(sessionName);
+        response = handleCurrentSession(sessionName);
+        break;
       case "list":
-        return handleListSessions();
+        response = await handleListSessions();
+        break;
       case "new":
-        return handleNewSession(sessionName, args.join(" "));
+        await handleNewSession(context, sessionName, args.join(" "));
+        return true;
       case "load":
-        return handleLoadSession(sessionName, args[0]);
+        response = await handleLoadSession(sessionName, args[0]);
+        break;
       case "close":
         await handleCloseSession(sessionName, args[0]);
-        return "Session closed. Next message will start a fresh session.";
+        response = "Session closed. Next message will start a fresh session.";
+        break;
       default:
-        return [
+        response = [
           "Usage:",
           "/session",
           "/session list",
@@ -152,6 +194,8 @@ export async function createHandler(config: AppConfig): Promise<{
           "/session close [sessionId]",
         ].join("\n");
     }
+    await sendTextResponse(context, response);
+    return true;
   }
 
   function handleStatus(): string {
@@ -164,16 +208,25 @@ state file: ${config.stateFile}
 prompt file: ${config.prompt.file ?? "none"}`;
   }
 
-  const handle = async (text: string, sessionName: string): Promise<string> => {
-    if (text === "/status") {
-      return handleStatus();
+  const handle = async (options: { session: string; context: Context }): Promise<void> => {
+    const message = options.context.message;
+    const text = message && "text" in message ? message.text : undefined;
+    if (!text) {
+      return;
     }
-    const sessionCommandResponse = await handleSessionCommand(text, sessionName);
-    if (sessionCommandResponse) {
-      return sessionCommandResponse;
+    const sessionName = options.session;
+
+    if (text === "/status") {
+      await sendTextResponse(options.context, handleStatus());
+      return;
+    }
+    const handledSessionCommand = await handleSessionCommand(options.context, text, sessionName);
+    if (handledSessionCommand) {
+      return;
     }
 
-    return handlePrompt({
+    await handlePrompt({
+      context: options.context,
       name: sessionName,
       text,
       sessionId: state.getSessionId(sessionName),
@@ -216,4 +269,44 @@ ${options.customPrompt.trim()}
 
 ${options.userText}
 `;
+}
+
+async function sendTextResponse(context: Context, text: string): Promise<void> {
+  const parts = splitMessageText(text);
+  for (const part of parts) {
+    await context.reply(part);
+  }
+}
+
+function splitMessageText(text: string): string[] {
+  const parts: string[] = [];
+  let remaining = text.trim();
+  while (remaining.length > MESSAGE_SPLIT_BUDGET) {
+    const splitIndex = findSplitIndex(remaining, MESSAGE_SPLIT_BUDGET);
+    const part = remaining.slice(0, splitIndex).trim();
+    if (part) {
+      parts.push(part);
+    }
+    remaining = remaining.slice(splitIndex).trim();
+  }
+  if (remaining) {
+    parts.push(remaining);
+  }
+  return parts;
+}
+
+function findSplitIndex(text: string, budget: number): number {
+  const paragraphIndex = text.lastIndexOf("\n\n", budget);
+  if (paragraphIndex > budget / 2) {
+    return paragraphIndex + 2;
+  }
+  const lineIndex = text.lastIndexOf("\n", budget);
+  if (lineIndex > budget / 2) {
+    return lineIndex + 1;
+  }
+  const spaceIndex = text.lastIndexOf(" ", budget);
+  if (spaceIndex > budget / 2) {
+    return spaceIndex + 1;
+  }
+  return budget;
 }

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -340,9 +340,9 @@ function createResponseWriter(options: { context: Context; limit: number }) {
 
   async function flushOversizedText(): Promise<void> {
     while (bufferedText.length > options.limit) {
-      const splitIndex = findSplitIndex(bufferedText, options.limit);
-      const part = bufferedText.slice(0, splitIndex).trim();
-      bufferedText = bufferedText.slice(splitIndex);
+      const result = splitHead(bufferedText, options.limit);
+      bufferedText = result.tail;
+      const part = result.head.trim();
       if (part) {
         await send(part);
       }
@@ -361,5 +361,13 @@ function createResponseWriter(options: { context: Context; limit: number }) {
         await options.context.reply("(no response)");
       }
     },
+  };
+}
+
+function splitHead(text: string, limit: number): { head: string; tail: string } {
+  const splitIndex = findSplitIndex(text, limit);
+  return {
+    head: text.slice(0, splitIndex),
+    tail: text.slice(splitIndex),
   };
 }

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -36,50 +36,24 @@ export async function createHandler(config: AppConfig): Promise<{
 
     try {
       const { queue } = session.prompt(promptText);
-      let bufferedText = "";
-      let sentResponse = false;
-
-      async function flushBufferedText(): Promise<void> {
-        if (!bufferedText.trim()) {
-          bufferedText = "";
-          return;
-        }
-        await sendTextResponse(options.context, bufferedText);
-        sentResponse = true;
-        bufferedText = "";
-      }
-
-      async function flushOversizedText(): Promise<void> {
-        while (bufferedText.length > MESSAGE_SPLIT_BUDGET) {
-          const splitIndex = findSplitIndex(bufferedText, MESSAGE_SPLIT_BUDGET);
-          const part = bufferedText.slice(0, splitIndex).trim();
-          bufferedText = bufferedText.slice(splitIndex);
-          if (part) {
-            await options.context.reply(part);
-            sentResponse = true;
-          }
-        }
-      }
+      const responseWriter = createResponseWriter({
+        context: options.context,
+        limit: MESSAGE_SPLIT_BUDGET,
+      });
 
       for await (const update of queue) {
         if (update.sessionUpdate === "agent_message_chunk" && update.content.type === "text") {
-          bufferedText += update.content.text;
-          await flushOversizedText();
+          await responseWriter.appendText(update.content.text);
         } else if (update.sessionUpdate === "tool_call") {
           console.log(`[acp:update] tool_call: ${update.title}`);
-          await flushBufferedText();
-          await sendTextResponse(options.context, `Tool: ${update.title}`);
-          sentResponse = true;
+          await responseWriter.sendToolCall(update.title);
         } else {
           console.log(`[acp:update] ${update.sessionUpdate}`);
         }
       }
-      await flushBufferedText();
+      await responseWriter.finish();
       if (!options.sessionId) {
         state.setSessionId(options.name, session.sessionId);
-      }
-      if (!sentResponse) {
-        await options.context.reply("(no response)");
       }
     } finally {
       session.close();
@@ -211,7 +185,11 @@ Usage:
 /session load <sessionId>
 /session close [sessionId]`;
     }
-    await sendTextResponse(options.context, response);
+    await sendTextResponse({
+      context: options.context,
+      limit: MESSAGE_SPLIT_BUDGET,
+      text: response,
+    });
     return true;
   }
 
@@ -230,7 +208,11 @@ prompt file: ${config.prompt.file ?? "none"}`;
     const sessionName = options.session;
 
     if (text === "/status") {
-      await sendTextResponse(options.context, handleStatus());
+      await sendTextResponse({
+        context: options.context,
+        limit: MESSAGE_SPLIT_BUDGET,
+        text: handleStatus(),
+      });
       return;
     }
     const handledSessionCommand = await handleSessionCommand({
@@ -288,10 +270,14 @@ ${options.userText}
 `;
 }
 
-async function sendTextResponse(context: Context, text: string): Promise<void> {
-  const parts = splitMessageText(text, MESSAGE_SPLIT_BUDGET);
+async function sendTextResponse(options: {
+  context: Context;
+  limit: number;
+  text: string;
+}): Promise<void> {
+  const parts = splitMessageText(options.text, options.limit);
   for (const part of parts) {
-    await context.reply(part);
+    await options.context.reply(part);
   }
 }
 
@@ -326,4 +312,61 @@ function findSplitIndex(text: string, budget: number): number {
     return spaceIndex + 1;
   }
   return budget;
+}
+
+function createResponseWriter(options: { context: Context; limit: number }) {
+  let bufferedText = "";
+  let sentResponse = false;
+
+  async function flushText(): Promise<void> {
+    if (!bufferedText.trim()) {
+      bufferedText = "";
+      return;
+    }
+    await sendTextResponse({
+      context: options.context,
+      limit: options.limit,
+      text: bufferedText,
+    });
+    sentResponse = true;
+    bufferedText = "";
+  }
+
+  async function flushOversizedText(): Promise<void> {
+    while (bufferedText.length > options.limit) {
+      const splitIndex = findSplitIndex(bufferedText, options.limit);
+      const part = bufferedText.slice(0, splitIndex).trim();
+      bufferedText = bufferedText.slice(splitIndex);
+      if (part) {
+        await sendTextResponse({
+          context: options.context,
+          limit: options.limit,
+          text: part,
+        });
+        sentResponse = true;
+      }
+    }
+  }
+
+  return {
+    async appendText(text: string): Promise<void> {
+      bufferedText += text;
+      await flushOversizedText();
+    },
+    async sendToolCall(title: string): Promise<void> {
+      await flushText();
+      await sendTextResponse({
+        context: options.context,
+        limit: options.limit,
+        text: `Tool: ${title}`,
+      });
+      sentResponse = true;
+    },
+    async finish(): Promise<void> {
+      await flushText();
+      if (!sentResponse) {
+        await options.context.reply("(no response)");
+      }
+    },
+  };
 }

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -287,12 +287,12 @@ function splitMessageText(text: string, limit: number): string[] {
   const parts: string[] = [];
   let remaining = text.trim();
   while (remaining.length > limit) {
-    const splitIndex = findSplitIndex(remaining, limit);
-    const part = remaining.slice(0, splitIndex).trim();
+    const result = splitHead(remaining, limit);
+    const part = result.head.trim();
     if (part) {
       parts.push(part);
     }
-    remaining = remaining.slice(splitIndex).trim();
+    remaining = result.tail.trim();
   }
   if (remaining) {
     parts.push(remaining);

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -209,11 +209,7 @@ prompt file: ${config.prompt.file ?? "none"}`;
   }
 
   const handle = async (options: { session: string; context: Context }): Promise<void> => {
-    const message = options.context.message;
-    const text = message && "text" in message ? message.text : undefined;
-    if (!text) {
-      return;
-    }
+    const text = options.context.message!.text!;
     const sessionName = options.session;
 
     if (text === "/status") {

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -268,17 +268,17 @@ ${options.userText}
 }
 
 async function sendTextResponse(context: Context, text: string): Promise<void> {
-  const parts = splitMessageText(text);
+  const parts = splitMessageText(text, MESSAGE_SPLIT_BUDGET);
   for (const part of parts) {
     await context.reply(part);
   }
 }
 
-function splitMessageText(text: string): string[] {
+function splitMessageText(text: string, limit: number): string[] {
   const parts: string[] = [];
   let remaining = text.trim();
-  while (remaining.length > MESSAGE_SPLIT_BUDGET) {
-    const splitIndex = findSplitIndex(remaining, MESSAGE_SPLIT_BUDGET);
+  while (remaining.length > limit) {
+    const splitIndex = findSplitIndex(remaining, limit);
     const part = remaining.slice(0, splitIndex).trim();
     if (part) {
       parts.push(part);


### PR DESCRIPTION
## Summary
- pass the grammY context into the handler so replies can be sent from the prompt loop
- flush buffered assistant text on ACP tool calls and send each tool call title as its own Telegram response
- split long outgoing messages before replying

## Tests
- Not run (per request)