### PR TITLE
fix: read custom prompt on each new session instead of service startup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@ Task docs should enable **handoff to a fresh agent** - include enough context to
 
 ## Conventions
 
+- Commit messages: use Conventional Commits (`feat:`, `fix:`, `docs:`, `refactor:`, `chore:`); add `!` for breaking changes
 - File names: kebab-case
 - Run `.ts` scripts with `node` (not `tsx`/`ts-node`)
 - Prefer `undefined` over `null`

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,3 @@
-import fs from "node:fs";
 import path from "node:path";
 import { z } from "zod";
 
@@ -14,9 +13,9 @@ export interface AppConfig {
     allowedUserIds: number[];
     allowedChatIds: number[];
   };
+  /** Conventional custom-instructions file, read lazily when creating a new session. */
   prompt: {
-    file?: string;
-    text?: string;
+    file: string;
   };
   testChatId: number;
 }
@@ -48,10 +47,6 @@ export function loadConfig(): AppConfig {
   const agentAlias = env.ACPELLA_AGENT ?? "codex";
   const agentCommand = builtinAgents[agentAlias] || agentAlias;
 
-  const agentsFilePath = path.join(home, ".acpella", "AGENTS.md");
-  const promptFile = fs.existsSync(agentsFilePath) ? agentsFilePath : undefined;
-  const promptText = promptFile ? fs.readFileSync(promptFile, "utf8") : undefined;
-
   return {
     agent: { alias: agentAlias, command: agentCommand },
     home,
@@ -62,8 +57,7 @@ export function loadConfig(): AppConfig {
       allowedChatIds: parseIdList(env.ACPELLA_TELEGRAM_ALLOWED_CHAT_IDS) ?? [],
     },
     prompt: {
-      file: promptFile,
-      text: promptText,
+      file: path.join(home, ".acpella", "AGENTS.md"),
     },
     // TODO: make use of this for test
     testChatId: parseOptionalId(env.ACPELLA_TEST_CHAT_ID) ?? 10101010,

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import type { ListSessionsResponse } from "@agentclientprotocol/sdk";
 import type { Context } from "grammy";
 import { startAcpManager } from "./acp/index.ts";
@@ -29,12 +30,15 @@ export async function createHandler(config: AppConfig): Promise<{
           sessionId: options.sessionId,
         })
       : await manager.newSession({ sessionCwd: config.home });
-    const promptText =
-      !options.sessionId && config.prompt.text
-        ? formatFirstPrompt({ customPrompt: config.prompt.text, userText: options.text })
-        : options.text;
 
     try {
+      const customPrompt = !options.sessionId
+        ? readOptionalPromptFile(config.prompt.file)
+        : undefined;
+      const promptText = customPrompt
+        ? formatFirstPrompt({ customPrompt, userText: options.text })
+        : options.text;
+
       const { queue } = session.prompt(promptText);
       const responseWriter = createResponseWriter({
         context: options.context,
@@ -270,6 +274,21 @@ ${options.customPrompt.trim()}
 
 ${options.userText}
 `;
+}
+
+function readOptionalPromptFile(file: string): string | undefined {
+  try {
+    return fs.readFileSync(file, "utf8");
+  } catch (error) {
+    if (isNodeError(error) && error.code === "ENOENT") {
+      return undefined;
+    }
+    throw error;
+  }
+}
+
+function isNodeError(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error;
 }
 
 async function sendTextResponse(options: {


### PR DESCRIPTION
## Summary
- Store the conventional .acpella/AGENTS.md path in config without checking or reading it at startup
- Read the prompt file lazily when creating a new session
- Treat a missing prompt file as no custom instructions while surfacing other read failures

Fixes #21

## Verification
- Not run (per request)