### PR TITLE
refactor!: default to test agent and require explicit ACPELLA_AGENT config

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Thin service that connects a messaging channel (Telegram) to AI agent via [ACP](
 ```bash
 pnpm install
 cp .env.example .env
-# fill in ACPELLA_TELEGRAM_BOT_TOKEN and ACPELLA_TELEGRAM_ALLOWED_USER_IDS
+# edit .env using the Config section below
 ```
 
 ## Run

--- a/README.md
+++ b/README.md
@@ -17,15 +17,19 @@ pnpm cli        # run service
 pnpm cli --repl # run local in-process REPL
 ```
 
+The default `ACPELLA_AGENT=test` uses the built-in echo agent. To use Codex ACP, install
+`@zed-industries/codex-acp` globally and set `ACPELLA_AGENT=codex-acp`. Known ACP agents are listed
+in the [ACP agent registry](https://agentclientprotocol.com/get-started/registry).
+
 ## Config
 
-| Variable                            | Required | Default                         | Description                                |
-| ----------------------------------- | -------- | ------------------------------- | ------------------------------------------ |
-| `ACPELLA_TELEGRAM_BOT_TOKEN`        | yes      | —                               | Bot token from @BotFather                  |
-| `ACPELLA_TELEGRAM_ALLOWED_USER_IDS` | yes      | —                               | Comma-separated numeric Telegram user IDs  |
-| `ACPELLA_TELEGRAM_ALLOWED_CHAT_IDS` | no       | —                               | Comma-separated chat IDs (group allowlist) |
-| `ACPELLA_AGENT`                     | no       | `npx @zed-industries/codex-acp` | acp agent command                          |
-| `ACPELLA_HOME`                      | no       | `process.cwd()`                 | Agent working directory                    |
+| Variable                            | Required | Default         | Description                                |
+| ----------------------------------- | -------- | --------------- | ------------------------------------------ |
+| `ACPELLA_TELEGRAM_BOT_TOKEN`        | yes      | —               | Bot token from @BotFather                  |
+| `ACPELLA_TELEGRAM_ALLOWED_USER_IDS` | yes      | —               | Comma-separated numeric Telegram user IDs  |
+| `ACPELLA_TELEGRAM_ALLOWED_CHAT_IDS` | no       | —               | Comma-separated chat IDs (group allowlist) |
+| `ACPELLA_AGENT`                     | no       | `test`          | acp agent command                          |
+| `ACPELLA_HOME`                      | no       | `process.cwd()` | Agent working directory                    |
 
 If `$ACPELLA_HOME/.acpella/AGENTS.md` exists, its contents are sent as custom instructions once when creating a new session.
 

--- a/README.md
+++ b/README.md
@@ -17,10 +17,6 @@ pnpm cli        # run service
 pnpm cli --repl # run local in-process REPL
 ```
 
-The default `ACPELLA_AGENT=test` uses the built-in echo agent. To use Codex ACP, install
-`@zed-industries/codex-acp` globally and set `ACPELLA_AGENT=codex-acp`. Known ACP agents are listed
-in the [ACP agent registry](https://agentclientprotocol.com/get-started/registry).
-
 ## Config
 
 | Variable                            | Required | Default         | Description                                |
@@ -30,6 +26,22 @@ in the [ACP agent registry](https://agentclientprotocol.com/get-started/registry
 | `ACPELLA_TELEGRAM_ALLOWED_CHAT_IDS` | no       | —               | Comma-separated chat IDs (group allowlist) |
 | `ACPELLA_AGENT`                     | no       | `test`          | acp agent command                          |
 | `ACPELLA_HOME`                      | no       | `process.cwd()` | Agent working directory                    |
+
+The default `ACPELLA_AGENT=test` uses the built-in echo agent. Set `ACPELLA_AGENT` to any ACP agent
+command to use a real agent. Known ACP agents are listed in the
+[ACP agent registry](https://agentclientprotocol.com/get-started/registry).
+
+For Codex ACP, either install `@zed-industries/codex-acp` globally and set:
+
+```env
+ACPELLA_AGENT=codex-acp
+```
+
+Or run it through `npx`:
+
+```env
+ACPELLA_AGENT="npx -y @zed-industries/codex-acp"
+```
 
 If `$ACPELLA_HOME/.acpella/AGENTS.md` exists, its contents are sent as custom instructions once when creating a new session.
 

--- a/README.md
+++ b/README.md
@@ -2,17 +2,13 @@
 
 Thin service that connects a messaging channel (Telegram) to AI agent via [ACP](https://github.com/agentclientprotocol/agent-client-protocol). Agent-agnostic — works with Codex, Claude Code, or any ACP-compatible agent.
 
-## Setup
+## Setup and Run
 
 ```bash
 pnpm install
 cp .env.example .env
 # edit .env using the Config section below
-```
 
-## Run
-
-```bash
 pnpm cli        # run service
 pnpm cli --repl # run local in-process REPL
 ```

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ pnpm cli --repl # run local in-process REPL
 | `ACPELLA_AGENT`                     | no       | `test`          | acp agent command                          |
 | `ACPELLA_HOME`                      | no       | `process.cwd()` | Agent working directory                    |
 
+### ACPELLA_AGENT
+
 The default `ACPELLA_AGENT=test` uses the built-in echo agent. Set `ACPELLA_AGENT` to any ACP agent
 command to use a real agent. Known ACP agents are listed in the
 [ACP agent registry](https://agentclientprotocol.com/get-started/registry).
@@ -43,7 +45,9 @@ Or run it through `npx`:
 ACPELLA_AGENT="npx -y @zed-industries/codex-acp"
 ```
 
-If `$ACPELLA_HOME/.acpella/AGENTS.md` exists, its contents are sent as custom instructions once when creating a new session.
+### `$ACPELLA_HOME/.acpella/AGENTS.md`
+
+If this file exists, its contents are sent as custom instructions once when creating a new session.
 
 ## Docs
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -9,7 +9,7 @@ git clone https://github.com/hi-ogawa/acpella
 cd acpella
 pnpm install
 cp .env.example .env
-# fill in ACPELLA_TELEGRAM_BOT_TOKEN and ACPELLA_TELEGRAM_ALLOWED_USER_IDS
+# edit .env using the README Config section
 ```
 
 ## systemd

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,7 +1,5 @@
 # Deploy
 
-Run acpella alongside existing openclaw on the same machine.
-
 ## Setup
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -11,13 +11,13 @@
     "lint-check": "vp check"
   },
   "dependencies": {
-    "@zed-industries/codex-acp": "^0.11.1",
     "grammy": "^1.42.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {
     "@agentclientprotocol/sdk": "^0.18.2",
     "@types/node": "^24.12.2",
+    "@zed-industries/codex-acp": "^0.11.1",
     "acpx": "^0.5.3",
     "typescript": "^6.0.2",
     "vite-plus": "^0.1.16",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      '@zed-industries/codex-acp':
-        specifier: ^0.11.1
-        version: 0.11.1
       grammy:
         specifier: ^1.42.0
         version: 1.42.0
@@ -24,6 +21,9 @@ importers:
       '@types/node':
         specifier: ^24.12.2
         version: 24.12.2
+      '@zed-industries/codex-acp':
+        specifier: ^0.11.1
+        version: 0.11.1
       acpx:
         specifier: ^0.5.3
         version: 0.5.3

--- a/src/config.ts
+++ b/src/config.ts
@@ -26,7 +26,7 @@ const builtinAgents: Record<string, string> = {
 
 const envSchema = z
   .object({
-    ACPELLA_AGENT: z.string().optional(),
+    ACPELLA_AGENT: z.string().default("test"),
     ACPELLA_HOME: z.string().optional(),
     ACPELLA_TELEGRAM_BOT_TOKEN: z.string().optional(),
     ACPELLA_TELEGRAM_ALLOWED_USER_IDS: z.string().optional(),
@@ -39,7 +39,7 @@ export function loadConfig(): AppConfig {
   const env = envSchema.parse(process.env);
   const home = env.ACPELLA_HOME ? path.resolve(env.ACPELLA_HOME) : process.cwd();
 
-  const agentAlias = env.ACPELLA_AGENT ?? "test";
+  const agentAlias = env.ACPELLA_AGENT;
   const agentCommand = builtinAgents[agentAlias] || agentAlias;
 
   return {

--- a/src/config.ts
+++ b/src/config.ts
@@ -31,7 +31,10 @@ const envSchema = z
     ACPELLA_TELEGRAM_BOT_TOKEN: z.string().optional(),
     ACPELLA_TELEGRAM_ALLOWED_USER_IDS: z.string().optional(),
     ACPELLA_TELEGRAM_ALLOWED_CHAT_IDS: z.string().optional(),
-    ACPELLA_TEST_CHAT_ID: z.string().optional(),
+    ACPELLA_TEST_CHAT_ID: z
+      .string()
+      .optional()
+      .transform((value) => (value?.trim() ? value : "10101010")),
   })
   .loose();
 
@@ -55,7 +58,7 @@ export function loadConfig(): AppConfig {
       file: path.join(home, ".acpella", "AGENTS.md"),
     },
     // TODO: make use of this for test
-    testChatId: parseOptionalId(env.ACPELLA_TEST_CHAT_ID) ?? 10101010,
+    testChatId: parseId(env.ACPELLA_TEST_CHAT_ID),
   };
 }
 
@@ -75,10 +78,7 @@ function parseIdList(value: string | undefined): number[] | undefined {
   });
 }
 
-function parseOptionalId(value: string | undefined): number | undefined {
-  if (value === undefined || value.trim() === "") {
-    return undefined;
-  }
+function parseId(value: string): number {
   const id = Number(value);
   if (!Number.isInteger(id)) {
     throw new Error(`Invalid numeric id: ${value}`);

--- a/src/config.ts
+++ b/src/config.ts
@@ -21,11 +21,6 @@ export interface AppConfig {
 }
 
 const builtinAgents: Record<string, string> = {
-  codex: path.join(
-    import.meta.dirname,
-    "..",
-    "node_modules/@zed-industries/codex-acp/bin/codex-acp.js",
-  ),
   test: `node ${path.join(import.meta.dirname, "lib/test-agent.ts")}`,
 };
 
@@ -44,7 +39,7 @@ export function loadConfig(): AppConfig {
   const env = envSchema.parse(process.env);
   const home = env.ACPELLA_HOME ? path.resolve(env.ACPELLA_HOME) : process.cwd();
 
-  const agentAlias = env.ACPELLA_AGENT ?? "codex";
+  const agentAlias = env.ACPELLA_AGENT ?? "test";
   const agentCommand = builtinAgents[agentAlias] || agentAlias;
 
   return {

--- a/src/e2e/codex/basic.test.ts
+++ b/src/e2e/codex/basic.test.ts
@@ -9,7 +9,7 @@ vi.setConfig({
 it("basic", async ({ onTestFinished }) => {
   const service = startService(
     {
-      ACPELLA_AGENT: "codex",
+      ACPELLA_AGENT: "codex-acp",
     },
     { sourceDir: path.join(import.meta.dirname, "fixtures/basic") },
   );
@@ -24,7 +24,7 @@ it("basic", async ({ onTestFinished }) => {
 it("uses custom prompt file", async ({ onTestFinished }) => {
   const service = startService(
     {
-      ACPELLA_AGENT: "codex",
+      ACPELLA_AGENT: "codex-acp",
     },
     { sourceDir: path.join(import.meta.dirname, "fixtures/custom-prompt") },
   );


### PR DESCRIPTION
## Summary

- default `ACPELLA_AGENT` to the built-in `test` agent
- remove the `codex` builtin alias that resolved to the repo-local Codex ACP package
- document using globally installed `codex-acp` and link the ACP agent registry

## Verification

- `pnpm test`
- `pnpm lint-check`