### PR TITLE
fix: generate stable systemd PATH

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -22,7 +22,15 @@ Example output:
 
 ```text
 Wrote /home/hiroshi/.config/systemd/user/acpella.service
-Run these commands to enable it:
+
+First install:
   systemctl --user daemon-reload
   systemctl --user enable --now acpella
+
+After updating this unit:
+  systemctl --user daemon-reload
+  systemctl --user restart acpella
+
+Logs:
+  journalctl --user -u acpella -f
 ```

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -15,12 +15,8 @@ cp .env.example .env
 Generate a user unit for the current checkout:
 
 ```bash
-pnpm cli --setup-systemd
-```
+$ pnpm cli --setup-systemd
 
-Example output:
-
-```text
 Wrote /home/hiroshi/.config/systemd/user/acpella.service
 
 First install:

--- a/docs/tasks/2026-04-13-stable-systemd-path.md
+++ b/docs/tasks/2026-04-13-stable-systemd-path.md
@@ -33,13 +33,13 @@ OpenClaw avoids volatile `/run/user/.../fnm_multishells/...` entries mostly by n
 
 - Add a small `buildServicePath` helper in `src/lib/systemd.ts`.
 - Put `dirname(process.execPath)` first in the rendered `PATH`.
-- Include stable user bin paths using `homedir()` and fallback system paths.
-- If acpella also uses selected entries from `process.env.PATH`, filter entries containing `/run/user/` and `/fnm_multishells/`; otherwise prefer the OpenClaw-style minimal path and avoid copying the host path.
+- Include fallback system paths.
+- Preserve selected entries from `process.env.PATH`, but filter entries containing `/run/user/` and `/fnm_multishells/`.
 - Render inline `Environment=HOME=...`, `Environment=TMPDIR=...`, and `Environment=PATH=...` lines.
 - Add `After=network-online.target` and `Wants=network-online.target`.
 - Add focused unit tests for:
   - Node bin directory is first.
   - transient fnm multishell entries are not included.
-  - fallback system paths are present.
+  - system fallback paths are present.
   - environment lines are escaped when needed.
 - Run `pnpm test` or at least the unit project for the changed tests, then `pnpm lint-check` if time permits.

--- a/docs/tasks/2026-04-13-stable-systemd-path.md
+++ b/docs/tasks/2026-04-13-stable-systemd-path.md
@@ -6,7 +6,7 @@ Issue: <https://github.com/hi-ogawa/acpella/issues/24>
 
 After reboot, `acpella.service` can start because the generated unit uses `process.execPath` as an absolute Node binary in `ExecStart`. Agent prompts can still fail when the configured ACP child process runs an npm package wrapper whose shebang is `#!/usr/bin/env node`. In that rebooted user-systemd environment, `PATH` may not include the active fnm Node installation and the host may not have `/usr/bin/node`, so the wrapper exits and acpella later sees `write EPIPE`.
 
-The fix should make `pnpm cli --setup-systemd` render a stable service environment. The unit should explicitly set `HOME`, `TMPDIR`, and `PATH`, put `dirname(process.execPath)` first, avoid transient fnm multishell path entries, and include fallback system paths.
+The fix should make `pnpm cli --setup-systemd` render a stable service environment. The unit should explicitly set `HOME`, `TMPDIR`, and `PATH`, put `dirname(process.execPath)` first, avoid copying transient login-shell path entries, and include fallback system paths.
 
 ## Reference files/patterns to follow
 
@@ -34,12 +34,12 @@ OpenClaw avoids volatile `/run/user/.../fnm_multishells/...` entries mostly by n
 - Add a small `buildServicePath` helper in `src/lib/systemd.ts`.
 - Put `dirname(process.execPath)` first in the rendered `PATH`.
 - Include fallback system paths.
-- Preserve selected entries from `process.env.PATH`, but filter entries containing `/run/user/` and `/fnm_multishells/`.
+- Do not copy `process.env.PATH`; this follows OpenClaw's minimal service PATH approach and avoids volatile entries such as `/run/user/.../fnm_multishells/...` by construction.
 - Render inline `Environment=HOME=...`, `Environment=TMPDIR=...`, and `Environment=PATH=...` lines.
 - Add `After=network-online.target` and `Wants=network-online.target`.
 - Add focused unit tests for:
   - Node bin directory is first.
-  - transient fnm multishell entries are not included.
+  - inherited login-shell path entries are not copied.
   - system fallback paths are present.
   - environment lines are escaped when needed.
 - Run `pnpm test` or at least the unit project for the changed tests, then `pnpm lint-check` if time permits.

--- a/docs/tasks/2026-04-13-stable-systemd-path.md
+++ b/docs/tasks/2026-04-13-stable-systemd-path.md
@@ -1,0 +1,45 @@
+# Stable systemd PATH for child Node tools
+
+## Problem context and approach
+
+Issue: <https://github.com/hi-ogawa/acpella/issues/24>
+
+After reboot, `acpella.service` can start because the generated unit uses `process.execPath` as an absolute Node binary in `ExecStart`. Agent prompts can still fail when the configured ACP child process runs an npm package wrapper whose shebang is `#!/usr/bin/env node`. In that rebooted user-systemd environment, `PATH` may not include the active fnm Node installation and the host may not have `/usr/bin/node`, so the wrapper exits and acpella later sees `write EPIPE`.
+
+The fix should make `pnpm cli --setup-systemd` render a stable service environment. The unit should explicitly set `HOME`, `TMPDIR`, and `PATH`, put `dirname(process.execPath)` first, avoid transient fnm multishell path entries, and include fallback system paths.
+
+## Reference files/patterns to follow
+
+- `src/lib/systemd.ts` owns the current acpella systemd unit rendering.
+- `docs/tasks/2026-04-12-systemd-unit-generator.md` is the previous task note for the systemd generator.
+- `refs/openclaw/src/daemon/systemd-unit.ts` renders canonical user-systemd units:
+  - Adds `After=network-online.target` and `Wants=network-online.target`.
+  - Renders service environment as inline `Environment=KEY=value` lines.
+  - Escapes values and rejects CR/LF in rendered systemd values.
+  - Uses `Restart=always`, short restart delays, explicit start/stop timeouts, and `KillMode=control-group`.
+- `refs/openclaw/src/daemon/service-env.ts` builds daemon environments:
+  - Sets `HOME` from the install environment.
+  - Sets `TMPDIR` from the host env, falling back to `os.tmpdir()`.
+  - Builds a minimal service `PATH` instead of copying the login-shell `PATH`.
+  - Prepends the selected Node runtime directory through `extraPathDirs`; install helpers pass `dirname(nodePath)`.
+  - Adds stable Linux user bin paths such as `~/.local/bin`, `~/.npm-global/bin`, `~/bin`, `~/.volta/bin`, `~/.asdf/shims`, `~/.bun/bin`, `~/.nvm/current/bin`, `~/.fnm/current/bin`, and `~/.local/share/pnpm`.
+  - Adds system fallback paths `/usr/local/bin`, `/usr/bin`, and `/bin`.
+  - De-duplicates while preserving first occurrence.
+- `refs/openclaw/src/commands/daemon-install-plan.shared.ts` has the small helper `resolveDaemonNodeBinDir(nodePath)` which returns `[dirname(nodePath)]` only for absolute paths.
+
+OpenClaw avoids volatile `/run/user/.../fnm_multishells/...` entries mostly by not deriving service `PATH` from `process.env.PATH` at all. It constructs a minimal deterministic path from the chosen runtime, stable user directories, and system fallback directories.
+
+## Implementation plan
+
+- Add a small `buildServicePath` helper in `src/lib/systemd.ts`.
+- Put `dirname(process.execPath)` first in the rendered `PATH`.
+- Include stable user bin paths using `homedir()` and fallback system paths.
+- If acpella also uses selected entries from `process.env.PATH`, filter entries containing `/run/user/` and `/fnm_multishells/`; otherwise prefer the OpenClaw-style minimal path and avoid copying the host path.
+- Render inline `Environment=HOME=...`, `Environment=TMPDIR=...`, and `Environment=PATH=...` lines.
+- Add `After=network-online.target` and `Wants=network-online.target`.
+- Add focused unit tests for:
+  - Node bin directory is first.
+  - transient fnm multishell entries are not included.
+  - fallback system paths are present.
+  - environment lines are escaped when needed.
+- Run `pnpm test` or at least the unit project for the changed tests, then `pnpm lint-check` if time permits.

--- a/src/lib/systemd.test.ts
+++ b/src/lib/systemd.test.ts
@@ -5,7 +5,6 @@ describe(buildServicePath, () => {
   it("puts the current Node bin directory first", () => {
     const pathValue = buildServicePath({
       envPath: "/usr/bin:/bin",
-      home: "/home/alice",
       nodeBin: "/home/alice/.local/share/fnm/node-versions/v24.13.0/installation/bin/node",
     });
 
@@ -17,7 +16,6 @@ describe(buildServicePath, () => {
   it("filters volatile fnm multishell directories from the inherited PATH", () => {
     const pathValue = buildServicePath({
       envPath: "/run/user/1000/fnm_multishells/123_456/bin:/home/alice/.local/bin:/custom/bin",
-      home: "/home/alice",
       nodeBin: "/home/alice/.local/share/fnm/node-versions/v24.13.0/installation/bin/node",
     });
 
@@ -25,28 +23,13 @@ describe(buildServicePath, () => {
     expect(pathValue.split(":")).toContain("/custom/bin");
   });
 
-  it("includes stable user and system fallback paths", () => {
+  it("includes system fallback paths", () => {
     const parts = buildServicePath({
       envPath: undefined,
-      home: "/home/alice",
       nodeBin: "/opt/node/bin/node",
     }).split(":");
 
-    expect(parts).toEqual([
-      "/opt/node/bin",
-      "/home/alice/.local/bin",
-      "/home/alice/.npm-global/bin",
-      "/home/alice/bin",
-      "/home/alice/.volta/bin",
-      "/home/alice/.asdf/shims",
-      "/home/alice/.bun/bin",
-      "/home/alice/.nvm/current/bin",
-      "/home/alice/.fnm/current/bin",
-      "/home/alice/.local/share/pnpm",
-      "/usr/local/bin",
-      "/usr/bin",
-      "/bin",
-    ]);
+    expect(parts).toEqual(["/opt/node/bin", "/usr/local/bin", "/usr/bin", "/bin"]);
   });
 });
 
@@ -83,6 +66,6 @@ describe(buildSystemdUnit, () => {
     });
 
     expect(unit).toContain('Environment="HOME=/home/alice with space"\n');
-    expect(unit).toContain('Environment="PATH=/opt/node/bin:');
+    expect(unit).toContain("Environment=PATH=/opt/node/bin:/usr/local/bin:/usr/bin:/bin\n");
   });
 });

--- a/src/lib/systemd.test.ts
+++ b/src/lib/systemd.test.ts
@@ -4,7 +4,6 @@ import { buildServicePath, buildSystemdUnit } from "./systemd.ts";
 describe(buildServicePath, () => {
   it("puts the current Node bin directory first", () => {
     const pathValue = buildServicePath({
-      envPath: "/usr/bin:/bin",
       nodeBin: "/home/alice/.local/share/fnm/node-versions/v24.13.0/installation/bin/node",
     });
 
@@ -13,19 +12,17 @@ describe(buildServicePath, () => {
     );
   });
 
-  it("filters volatile fnm multishell directories from the inherited PATH", () => {
+  it("does not copy the inherited PATH", () => {
     const pathValue = buildServicePath({
-      envPath: "/run/user/1000/fnm_multishells/123_456/bin:/home/alice/.local/bin:/custom/bin",
       nodeBin: "/home/alice/.local/share/fnm/node-versions/v24.13.0/installation/bin/node",
     });
 
     expect(pathValue).not.toContain("fnm_multishells");
-    expect(pathValue.split(":")).toContain("/custom/bin");
+    expect(pathValue.split(":")).not.toContain("/custom/bin");
   });
 
   it("includes system fallback paths", () => {
     const parts = buildServicePath({
-      envPath: undefined,
       nodeBin: "/opt/node/bin/node",
     }).split(":");
 
@@ -51,7 +48,7 @@ describe(buildSystemdUnit, () => {
     expect(unit).toContain("Environment=HOME=/home/alice\n");
     expect(unit).toContain("Environment=TMPDIR=/var/tmp/acpella\n");
     expect(unit).toContain(
-      "Environment=PATH=/home/alice/.local/share/fnm/node-versions/v24.13.0/installation/bin:/usr/bin",
+      "Environment=PATH=/home/alice/.local/share/fnm/node-versions/v24.13.0/installation/bin:/usr/local/bin:/usr/bin:/bin",
     );
     expect(unit).not.toContain("fnm_multishells");
   });

--- a/src/lib/systemd.test.ts
+++ b/src/lib/systemd.test.ts
@@ -9,32 +9,19 @@ describe(buildSystemdUnit, () => {
         PATH: "/run/user/1000/fnm_multishells/123_456/bin:/custom/bin:/usr/bin",
         TMPDIR: "/var/tmp/acpella",
       },
-      home: "/home/alice",
+      home: "/home/alice with space",
       nodeBin: "/home/alice/.local/share/fnm/node-versions/v24.13.0/installation/bin/node",
       tmpDir: "/tmp",
     });
 
     expect(unit).toContain("After=network-online.target\n");
     expect(unit).toContain("Wants=network-online.target\n");
-    expect(unit).toContain("Environment=HOME=/home/alice\n");
+    expect(unit).toContain('Environment="HOME=/home/alice with space"\n');
     expect(unit).toContain("Environment=TMPDIR=/var/tmp/acpella\n");
     expect(unit).toContain(
       "Environment=PATH=/home/alice/.local/share/fnm/node-versions/v24.13.0/installation/bin:/usr/local/bin:/usr/bin:/bin",
     );
     expect(unit).not.toContain("fnm_multishells");
     expect(unit).not.toContain("/custom/bin");
-  });
-
-  it("quotes environment lines that contain spaces", () => {
-    const unit = buildSystemdUnit({
-      workingDirectory: "/home/alice/code/acpella",
-      env: {},
-      home: "/home/alice with space",
-      nodeBin: "/opt/node/bin/node",
-      tmpDir: "/tmp",
-    });
-
-    expect(unit).toContain('Environment="HOME=/home/alice with space"\n');
-    expect(unit).toContain("Environment=PATH=/opt/node/bin:/usr/local/bin:/usr/bin:/bin\n");
   });
 });

--- a/src/lib/systemd.test.ts
+++ b/src/lib/systemd.test.ts
@@ -1,41 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { buildServicePath, buildSystemdUnit } from "./systemd.ts";
-
-describe(buildServicePath, () => {
-  it("puts the current Node bin directory first", () => {
-    const pathValue = buildServicePath({
-      nodeBin: "/home/alice/.local/share/fnm/node-versions/v24.13.0/installation/bin/node",
-    });
-
-    expect(pathValue.split(":")[0]).toBe(
-      "/home/alice/.local/share/fnm/node-versions/v24.13.0/installation/bin",
-    );
-  });
-
-  it("does not copy the inherited PATH", () => {
-    const pathValue = buildServicePath({
-      nodeBin: "/home/alice/.local/share/fnm/node-versions/v24.13.0/installation/bin/node",
-    });
-
-    expect(pathValue).not.toContain("fnm_multishells");
-    expect(pathValue.split(":")).not.toContain("/custom/bin");
-  });
-
-  it("includes system fallback paths", () => {
-    const parts = buildServicePath({
-      nodeBin: "/opt/node/bin/node",
-    }).split(":");
-
-    expect(parts).toEqual(["/opt/node/bin", "/usr/local/bin", "/usr/bin", "/bin"]);
-  });
-});
+import { buildSystemdUnit } from "./systemd.ts";
 
 describe(buildSystemdUnit, () => {
   it("renders network ordering and stable environment lines", () => {
     const unit = buildSystemdUnit({
       workingDirectory: "/home/alice/code/acpella",
       env: {
-        PATH: "/run/user/1000/fnm_multishells/123_456/bin:/usr/bin",
+        PATH: "/run/user/1000/fnm_multishells/123_456/bin:/custom/bin:/usr/bin",
         TMPDIR: "/var/tmp/acpella",
       },
       home: "/home/alice",
@@ -51,6 +22,7 @@ describe(buildSystemdUnit, () => {
       "Environment=PATH=/home/alice/.local/share/fnm/node-versions/v24.13.0/installation/bin:/usr/local/bin:/usr/bin:/bin",
     );
     expect(unit).not.toContain("fnm_multishells");
+    expect(unit).not.toContain("/custom/bin");
   });
 
   it("quotes environment lines that contain spaces", () => {

--- a/src/lib/systemd.test.ts
+++ b/src/lib/systemd.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { buildSystemdUnit } from "./systemd.ts";
 
 describe(buildSystemdUnit, () => {
-  it("renders network ordering and stable environment lines", () => {
+  it("basic", () => {
     const unit = buildSystemdUnit({
       workingDirectory: "/home/alice/code/acpella",
       env: {
@@ -13,15 +13,27 @@ describe(buildSystemdUnit, () => {
       nodeBin: "/home/alice/.local/share/fnm/node-versions/v24.13.0/installation/bin/node",
       tmpDir: "/tmp",
     });
+    expect(unit).toMatchInlineSnapshot(`
+      "[Unit]
+      Description="acpella service"
+      After=network-online.target
+      Wants=network-online.target
 
-    expect(unit).toContain("After=network-online.target\n");
-    expect(unit).toContain("Wants=network-online.target\n");
-    expect(unit).toContain('Environment="HOME=/home/alice with space"\n');
-    expect(unit).toContain("Environment=TMPDIR=/var/tmp/acpella\n");
-    expect(unit).toContain(
-      "Environment=PATH=/home/alice/.local/share/fnm/node-versions/v24.13.0/installation/bin:/usr/local/bin:/usr/bin:/bin",
-    );
-    expect(unit).not.toContain("fnm_multishells");
-    expect(unit).not.toContain("/custom/bin");
+      [Service]
+      Type=simple
+      SyslogIdentifier=acpella
+      WorkingDirectory=/home/alice/code/acpella
+      EnvironmentFile=/home/alice/code/acpella/.env
+      Environment="HOME=/home/alice with space"
+      Environment=TMPDIR=/var/tmp/acpella
+      Environment=PATH=/home/alice/.local/share/fnm/node-versions/v24.13.0/installation/bin:/usr/local/bin:/usr/bin:/bin
+      ExecStart=/home/alice/.local/share/fnm/node-versions/v24.13.0/installation/bin/node /home/alice/code/acpella/src/cli.ts
+      Restart=on-failure
+      RestartSec=10
+
+      [Install]
+      WantedBy=default.target
+      "
+    `);
   });
 });

--- a/src/lib/systemd.test.ts
+++ b/src/lib/systemd.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import { buildServicePath, buildSystemdUnit } from "./systemd.ts";
+
+describe(buildServicePath, () => {
+  it("puts the current Node bin directory first", () => {
+    const pathValue = buildServicePath({
+      envPath: "/usr/bin:/bin",
+      home: "/home/alice",
+      nodeBin: "/home/alice/.local/share/fnm/node-versions/v24.13.0/installation/bin/node",
+    });
+
+    expect(pathValue.split(":")[0]).toBe(
+      "/home/alice/.local/share/fnm/node-versions/v24.13.0/installation/bin",
+    );
+  });
+
+  it("filters volatile fnm multishell directories from the inherited PATH", () => {
+    const pathValue = buildServicePath({
+      envPath: "/run/user/1000/fnm_multishells/123_456/bin:/home/alice/.local/bin:/custom/bin",
+      home: "/home/alice",
+      nodeBin: "/home/alice/.local/share/fnm/node-versions/v24.13.0/installation/bin/node",
+    });
+
+    expect(pathValue).not.toContain("fnm_multishells");
+    expect(pathValue.split(":")).toContain("/custom/bin");
+  });
+
+  it("includes stable user and system fallback paths", () => {
+    const parts = buildServicePath({
+      envPath: undefined,
+      home: "/home/alice",
+      nodeBin: "/opt/node/bin/node",
+    }).split(":");
+
+    expect(parts).toEqual([
+      "/opt/node/bin",
+      "/home/alice/.local/bin",
+      "/home/alice/.npm-global/bin",
+      "/home/alice/bin",
+      "/home/alice/.volta/bin",
+      "/home/alice/.asdf/shims",
+      "/home/alice/.bun/bin",
+      "/home/alice/.nvm/current/bin",
+      "/home/alice/.fnm/current/bin",
+      "/home/alice/.local/share/pnpm",
+      "/usr/local/bin",
+      "/usr/bin",
+      "/bin",
+    ]);
+  });
+});
+
+describe(buildSystemdUnit, () => {
+  it("renders network ordering and stable environment lines", () => {
+    const unit = buildSystemdUnit({
+      workingDirectory: "/home/alice/code/acpella",
+      env: {
+        PATH: "/run/user/1000/fnm_multishells/123_456/bin:/usr/bin",
+        TMPDIR: "/var/tmp/acpella",
+      },
+      home: "/home/alice",
+      nodeBin: "/home/alice/.local/share/fnm/node-versions/v24.13.0/installation/bin/node",
+      tmpDir: "/tmp",
+    });
+
+    expect(unit).toContain("After=network-online.target\n");
+    expect(unit).toContain("Wants=network-online.target\n");
+    expect(unit).toContain("Environment=HOME=/home/alice\n");
+    expect(unit).toContain("Environment=TMPDIR=/var/tmp/acpella\n");
+    expect(unit).toContain(
+      "Environment=PATH=/home/alice/.local/share/fnm/node-versions/v24.13.0/installation/bin:/usr/bin",
+    );
+    expect(unit).not.toContain("fnm_multishells");
+  });
+
+  it("quotes environment lines that contain spaces", () => {
+    const unit = buildSystemdUnit({
+      workingDirectory: "/home/alice/code/acpella",
+      env: {},
+      home: "/home/alice with space",
+      nodeBin: "/opt/node/bin/node",
+      tmpDir: "/tmp",
+    });
+
+    expect(unit).toContain('Environment="HOME=/home/alice with space"\n');
+    expect(unit).toContain('Environment="PATH=/opt/node/bin:');
+  });
+});

--- a/src/lib/systemd.ts
+++ b/src/lib/systemd.ts
@@ -62,17 +62,8 @@ WantedBy=default.target
 
 export function buildServicePath(options: { nodeBin: string }): string {
   const dirs = [dirname(options.nodeBin), "/usr/local/bin", "/usr/bin", "/bin"];
-  const seen = new Set<string>();
 
-  return dirs
-    .filter((dir) => {
-      if (!dir || seen.has(dir)) {
-        return false;
-      }
-      seen.add(dir);
-      return true;
-    })
-    .join(":");
+  return [...new Set(dirs)].join(":");
 }
 
 function renderEnvironmentLines(env: Record<string, string>): string {

--- a/src/lib/systemd.ts
+++ b/src/lib/systemd.ts
@@ -29,9 +29,7 @@ export function buildSystemdUnit(options: {
   nodeBin: string;
   tmpDir: string;
 }): string {
-  const description = "acpella service";
   const envFile = resolve(options.workingDirectory, ".env");
-  const serviceName = "acpella";
   const pathDirs = [dirname(options.nodeBin), "/usr/local/bin", "/usr/bin", "/bin"];
   const serviceEnv = {
     HOME: options.home,
@@ -43,13 +41,13 @@ export function buildSystemdUnit(options: {
     .join("\n");
 
   return `[Unit]
-Description=${escapeSystemdValue(description)}
+Description=${escapeSystemdValue("acpella service")}
 After=network-online.target
 Wants=network-online.target
 
 [Service]
 Type=simple
-SyslogIdentifier=${escapeSystemdValue(serviceName)}
+SyslogIdentifier=${escapeSystemdValue("acpella")}
 WorkingDirectory=${escapeSystemdValue(options.workingDirectory)}
 EnvironmentFile=${escapeSystemdValue(envFile)}
 ${environmentLines}

--- a/src/lib/systemd.ts
+++ b/src/lib/systemd.ts
@@ -62,25 +62,23 @@ WantedBy=default.target
 
 export function buildServicePath(options: { nodeBin: string }): string {
   const dirs = [dirname(options.nodeBin), "/usr/local/bin", "/usr/bin", "/bin"];
+  const seen = new Set<string>();
 
-  return uniqueNonEmpty(dirs).join(":");
+  return dirs
+    .filter((dir) => {
+      if (!dir || seen.has(dir)) {
+        return false;
+      }
+      seen.add(dir);
+      return true;
+    })
+    .join(":");
 }
 
 function renderEnvironmentLines(env: Record<string, string>): string {
   return Object.entries(env)
     .map(([key, value]) => `Environment=${escapeSystemdValue(`${key}=${value}`)}`)
     .join("\n");
-}
-
-function uniqueNonEmpty(values: string[]): string[] {
-  const result: string[] = [];
-  for (const value of values) {
-    if (!value || result.includes(value)) {
-      continue;
-    }
-    result.push(value);
-  }
-  return result;
 }
 
 function escapeSystemdValue(value: string): string {

--- a/src/lib/systemd.ts
+++ b/src/lib/systemd.ts
@@ -3,23 +3,24 @@ import { homedir, tmpdir } from "node:os";
 import { dirname, resolve } from "node:path";
 
 export function handleSetupSystemd(): void {
-  const workingDirectory = process.cwd();
-  const unitFile = resolve(homedir(), ".config/systemd/user/acpella.service");
-  const unit = buildSystemdUnit({
-    workingDirectory,
+  const unitContent = buildSystemdUnit({
+    workingDirectory: process.cwd(),
     env: process.env,
     home: homedir(),
     nodeBin: process.execPath,
     tmpDir: tmpdir(),
   });
 
+  const unitFile = resolve(homedir(), ".config/systemd/user/acpella.service");
   mkdirSync(dirname(unitFile), { recursive: true });
-  writeFileSync(unitFile, unit);
+  writeFileSync(unitFile, unitContent);
 
-  console.log(`Wrote ${unitFile}`);
-  console.log("Run these commands to enable it:");
-  console.log("  systemctl --user daemon-reload");
-  console.log("  systemctl --user enable --now acpella");
+  console.log(`\
+Wrote ${unitFile}
+Run these commands to enable it:
+  systemctl --user daemon-reload
+  systemctl --user enable --now acpella
+`);
 }
 
 export function buildSystemdUnit(options: {

--- a/src/lib/systemd.ts
+++ b/src/lib/systemd.ts
@@ -17,9 +17,17 @@ export function handleSetupSystemd(): void {
 
   console.log(`\
 Wrote ${unitFile}
-Run these commands to enable it:
+
+First install:
   systemctl --user daemon-reload
   systemctl --user enable --now acpella
+
+After updating this unit:
+  systemctl --user daemon-reload
+  systemctl --user restart acpella
+
+Logs:
+  journalctl --user -u acpella -f
 `);
 }
 

--- a/src/lib/systemd.ts
+++ b/src/lib/systemd.ts
@@ -32,12 +32,11 @@ export function buildSystemdUnit(options: {
   const description = "acpella service";
   const envFile = resolve(options.workingDirectory, ".env");
   const serviceName = "acpella";
+  const pathDirs = [dirname(options.nodeBin), "/usr/local/bin", "/usr/bin", "/bin"];
   const serviceEnv = {
     HOME: options.home,
     TMPDIR: options.env.TMPDIR?.trim() || options.tmpDir,
-    PATH: buildServicePath({
-      nodeBin: options.nodeBin,
-    }),
+    PATH: [...new Set(pathDirs)].join(":"),
   };
   const environmentLines = Object.entries(serviceEnv)
     .map(([key, value]) => `Environment=${escapeSystemdValue(`${key}=${value}`)}`)
@@ -61,12 +60,6 @@ RestartSec=10
 [Install]
 WantedBy=default.target
 `;
-}
-
-export function buildServicePath(options: { nodeBin: string }): string {
-  const dirs = [dirname(options.nodeBin), "/usr/local/bin", "/usr/bin", "/bin"];
-
-  return [...new Set(dirs)].join(":");
 }
 
 function escapeSystemdValue(value: string): string {

--- a/src/lib/systemd.ts
+++ b/src/lib/systemd.ts
@@ -40,7 +40,8 @@ export function buildSystemdUnit(options: {
     .map(([key, value]) => `Environment=${escapeSystemdValue(`${key}=${value}`)}`)
     .join("\n");
 
-  return `[Unit]
+  return `\
+[Unit]
 Description=${escapeSystemdValue("acpella service")}
 After=network-online.target
 Wants=network-online.target

--- a/src/lib/systemd.ts
+++ b/src/lib/systemd.ts
@@ -36,7 +36,6 @@ export function buildSystemdUnit(options: {
     HOME: options.home,
     TMPDIR: options.env.TMPDIR?.trim() || options.tmpDir,
     PATH: buildServicePath({
-      envPath: options.env.PATH,
       nodeBin: options.nodeBin,
     }),
   };
@@ -61,19 +60,8 @@ WantedBy=default.target
 `;
 }
 
-export function buildServicePath(options: {
-  envPath: string | undefined;
-  nodeBin: string;
-}): string {
-  const dirs = [
-    dirname(options.nodeBin),
-    ...splitPath(options.envPath).filter(
-      (entry) => !(entry.includes("/run/user/") && entry.includes("/fnm_multishells/")),
-    ),
-    "/usr/local/bin",
-    "/usr/bin",
-    "/bin",
-  ];
+export function buildServicePath(options: { nodeBin: string }): string {
+  const dirs = [dirname(options.nodeBin), "/usr/local/bin", "/usr/bin", "/bin"];
 
   return uniqueNonEmpty(dirs).join(":");
 }
@@ -82,10 +70,6 @@ function renderEnvironmentLines(env: Record<string, string>): string {
   return Object.entries(env)
     .map(([key, value]) => `Environment=${escapeSystemdValue(`${key}=${value}`)}`)
     .join("\n");
-}
-
-function splitPath(pathValue: string | undefined): string[] {
-  return (pathValue ?? "").split(":").map((entry) => entry.trim());
 }
 
 function uniqueNonEmpty(values: string[]): string[] {

--- a/src/lib/systemd.ts
+++ b/src/lib/systemd.ts
@@ -1,30 +1,17 @@
 import { mkdirSync, writeFileSync } from "node:fs";
-import { homedir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { dirname, resolve } from "node:path";
 
 export function handleSetupSystemd(): void {
   const workingDirectory = process.cwd();
-  const description = "acpella service";
-  const envFile = resolve(workingDirectory, ".env");
-  const nodeBin = process.execPath;
-  const serviceName = "acpella";
   const unitFile = resolve(homedir(), ".config/systemd/user/acpella.service");
-
-  const unit = `[Unit]
-Description=${escapeSystemdValue(description)}
-
-[Service]
-Type=simple
-SyslogIdentifier=${escapeSystemdValue(serviceName)}
-WorkingDirectory=${escapeSystemdValue(workingDirectory)}
-EnvironmentFile=${escapeSystemdValue(envFile)}
-ExecStart=${escapeSystemdValue(nodeBin)} ${escapeSystemdValue(resolve(workingDirectory, "src/cli.ts"))}
-Restart=on-failure
-RestartSec=10
-
-[Install]
-WantedBy=default.target
-`;
+  const unit = buildSystemdUnit({
+    workingDirectory,
+    env: process.env,
+    home: homedir(),
+    nodeBin: process.execPath,
+    tmpDir: tmpdir(),
+  });
 
   mkdirSync(dirname(unitFile), { recursive: true });
   writeFileSync(unitFile, unit);
@@ -33,6 +20,102 @@ WantedBy=default.target
   console.log("Run these commands to enable it:");
   console.log("  systemctl --user daemon-reload");
   console.log("  systemctl --user enable --now acpella");
+}
+
+export function buildSystemdUnit(options: {
+  workingDirectory: string;
+  env: NodeJS.ProcessEnv;
+  home: string;
+  nodeBin: string;
+  tmpDir: string;
+}): string {
+  const description = "acpella service";
+  const envFile = resolve(options.workingDirectory, ".env");
+  const serviceName = "acpella";
+  const serviceEnv = {
+    HOME: options.home,
+    TMPDIR: options.env.TMPDIR?.trim() || options.tmpDir,
+    PATH: buildServicePath({
+      envPath: options.env.PATH,
+      home: options.home,
+      nodeBin: options.nodeBin,
+    }),
+  };
+
+  return `[Unit]
+Description=${escapeSystemdValue(description)}
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+SyslogIdentifier=${escapeSystemdValue(serviceName)}
+WorkingDirectory=${escapeSystemdValue(options.workingDirectory)}
+EnvironmentFile=${escapeSystemdValue(envFile)}
+${renderEnvironmentLines(serviceEnv)}
+ExecStart=${escapeSystemdValue(options.nodeBin)} ${escapeSystemdValue(resolve(options.workingDirectory, "src/cli.ts"))}
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=default.target
+`;
+}
+
+export function buildServicePath(options: {
+  envPath: string | undefined;
+  home: string;
+  nodeBin: string;
+}): string {
+  const dirs = [
+    dirname(options.nodeBin),
+    ...splitPath(options.envPath).filter((entry) => !isVolatilePathEntry(entry)),
+    ...stableUserBinDirs(options.home),
+    "/usr/local/bin",
+    "/usr/bin",
+    "/bin",
+  ];
+
+  return uniqueNonEmpty(dirs).join(":");
+}
+
+function renderEnvironmentLines(env: Record<string, string>): string {
+  return Object.entries(env)
+    .map(([key, value]) => `Environment=${escapeSystemdValue(`${key}=${value}`)}`)
+    .join("\n");
+}
+
+function splitPath(pathValue: string | undefined): string[] {
+  return (pathValue ?? "").split(":").map((entry) => entry.trim());
+}
+
+function stableUserBinDirs(home: string): string[] {
+  return [
+    `${home}/.local/bin`,
+    `${home}/.npm-global/bin`,
+    `${home}/bin`,
+    `${home}/.volta/bin`,
+    `${home}/.asdf/shims`,
+    `${home}/.bun/bin`,
+    `${home}/.nvm/current/bin`,
+    `${home}/.fnm/current/bin`,
+    `${home}/.local/share/pnpm`,
+  ];
+}
+
+function isVolatilePathEntry(entry: string): boolean {
+  return entry.includes("/run/user/") && entry.includes("/fnm_multishells/");
+}
+
+function uniqueNonEmpty(values: string[]): string[] {
+  const result: string[] = [];
+  for (const value of values) {
+    if (!value || result.includes(value)) {
+      continue;
+    }
+    result.push(value);
+  }
+  return result;
 }
 
 function escapeSystemdValue(value: string): string {

--- a/src/lib/systemd.ts
+++ b/src/lib/systemd.ts
@@ -37,7 +37,6 @@ export function buildSystemdUnit(options: {
     TMPDIR: options.env.TMPDIR?.trim() || options.tmpDir,
     PATH: buildServicePath({
       envPath: options.env.PATH,
-      home: options.home,
       nodeBin: options.nodeBin,
     }),
   };
@@ -64,13 +63,13 @@ WantedBy=default.target
 
 export function buildServicePath(options: {
   envPath: string | undefined;
-  home: string;
   nodeBin: string;
 }): string {
   const dirs = [
     dirname(options.nodeBin),
-    ...splitPath(options.envPath).filter((entry) => !isVolatilePathEntry(entry)),
-    ...stableUserBinDirs(options.home),
+    ...splitPath(options.envPath).filter(
+      (entry) => !(entry.includes("/run/user/") && entry.includes("/fnm_multishells/")),
+    ),
     "/usr/local/bin",
     "/usr/bin",
     "/bin",
@@ -87,24 +86,6 @@ function renderEnvironmentLines(env: Record<string, string>): string {
 
 function splitPath(pathValue: string | undefined): string[] {
   return (pathValue ?? "").split(":").map((entry) => entry.trim());
-}
-
-function stableUserBinDirs(home: string): string[] {
-  return [
-    `${home}/.local/bin`,
-    `${home}/.npm-global/bin`,
-    `${home}/bin`,
-    `${home}/.volta/bin`,
-    `${home}/.asdf/shims`,
-    `${home}/.bun/bin`,
-    `${home}/.nvm/current/bin`,
-    `${home}/.fnm/current/bin`,
-    `${home}/.local/share/pnpm`,
-  ];
-}
-
-function isVolatilePathEntry(entry: string): boolean {
-  return entry.includes("/run/user/") && entry.includes("/fnm_multishells/");
 }
 
 function uniqueNonEmpty(values: string[]): string[] {

--- a/src/lib/systemd.ts
+++ b/src/lib/systemd.ts
@@ -39,6 +39,9 @@ export function buildSystemdUnit(options: {
       nodeBin: options.nodeBin,
     }),
   };
+  const environmentLines = Object.entries(serviceEnv)
+    .map(([key, value]) => `Environment=${escapeSystemdValue(`${key}=${value}`)}`)
+    .join("\n");
 
   return `[Unit]
 Description=${escapeSystemdValue(description)}
@@ -50,7 +53,7 @@ Type=simple
 SyslogIdentifier=${escapeSystemdValue(serviceName)}
 WorkingDirectory=${escapeSystemdValue(options.workingDirectory)}
 EnvironmentFile=${escapeSystemdValue(envFile)}
-${renderEnvironmentLines(serviceEnv)}
+${environmentLines}
 ExecStart=${escapeSystemdValue(options.nodeBin)} ${escapeSystemdValue(resolve(options.workingDirectory, "src/cli.ts"))}
 Restart=on-failure
 RestartSec=10
@@ -64,12 +67,6 @@ export function buildServicePath(options: { nodeBin: string }): string {
   const dirs = [dirname(options.nodeBin), "/usr/local/bin", "/usr/bin", "/bin"];
 
   return [...new Set(dirs)].join(":");
-}
-
-function renderEnvironmentLines(env: Record<string, string>): string {
-  return Object.entries(env)
-    .map(([key, value]) => `Environment=${escapeSystemdValue(`${key}=${value}`)}`)
-    .join("\n");
 }
 
 function escapeSystemdValue(value: string): string {


### PR DESCRIPTION
## Summary

- document OpenClaw's minimal service PATH approach in a new task note
- render HOME, TMPDIR, and a deterministic PATH in the generated user systemd unit
- put the active Node runtime directory first so #!/usr/bin/env node child wrappers resolve after reboot
- add network-online.target ordering and focused unit coverage

## Verification

- pnpm test -- src/lib/systemd.test.ts
- pnpm lint-check
- pnpm test

Fixes #24