### PR TITLE
[codex] show checkout in status

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import type { ListSessionsResponse } from "@agentclientprotocol/sdk";
 import type { Context } from "grammy";
@@ -284,6 +285,7 @@ Usage:
   function handleStatus(): string {
     return `\
 service state: running
+checkout: ${getCheckoutStatus()}
 configured agent: ${config.agent.alias}
 agent command: ${config.agent.command}
 home: ${config.home}
@@ -335,6 +337,25 @@ prompt file: ${config.prompt.file ?? "none"}`;
   };
 
   return { handle };
+}
+
+function getCheckoutStatus(): string {
+  try {
+    const branch = execGit(["branch", "--show-current"]) || "detached";
+    const commit = execGit(["rev-parse", "--short", "HEAD"]);
+    const dirty = execGit(["status", "--porcelain"]) ? " dirty" : "";
+    return `${branch} ${commit}${dirty}`;
+  } catch {
+    return "unknown";
+  }
+}
+
+function execGit(args: string[]): string {
+  return execFileSync("git", args, {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  }).trim();
 }
 
 function formatStateSessions(sessions: StateSession[]): string[] {


### PR DESCRIPTION
## Summary

Adds the current acpella checkout to /status output so the running service can report which branch and commit it is serving from.

The status line is best effort:

- shows <branch> <short-sha> in normal checkouts
- appends dirty when local files differ from HEAD
- falls back to unknown when git metadata is unavailable

## Validation

- pnpm test
- pnpm lint
- pnpm lint-check