### PR TITLE
refactor: consolidate reply helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,3 +42,4 @@ Task docs should enable **handoff to a fresh agent** - include enough context to
 ## Rule
 
 - Never remove `TODO: review slop` comment
+- Do not update existing `docs/tasks/*` notes just to reflect code refactors unless explicitly asked.

--- a/docs/tasks/2026-04-14-openclaw-reply-streaming-notes.md
+++ b/docs/tasks/2026-04-14-openclaw-reply-streaming-notes.md
@@ -1,0 +1,111 @@
+# OpenClaw Reply Streaming Notes
+
+## Problem context and approach
+
+`src/lib/reply.ts` currently buffers streamed agent text until one of these happens:
+
+- the buffer exceeds `MESSAGE_SPLIT_BUDGET`
+- the caller explicitly calls `flush()`
+- the caller calls `finish()`
+
+This is simple and safe, but it can delay short or medium responses until the full agent turn completes. We inspected `refs/openclaw` for reference patterns around timeout-based flushing and draft/rewrite-style previews.
+
+## Reference files/patterns to follow
+
+- `refs/openclaw/src/channels/draft-stream-loop.ts`
+  - Generic throttled draft update loop.
+  - Tracks `pendingText`, `lastSentAt`, one timer, and one in-flight send promise.
+  - `update(text)` replaces pending text rather than appending.
+  - Sends immediately when outside the throttle window, otherwise schedules a timer.
+  - `flush()` clears the timer, waits for in-flight work, sends pending text, and loops if more text arrived during the send.
+  - If `sendOrEditStreamMessage()` returns `false`, it restores pending text and stops.
+  - `stop()` clears pending text and the timer; `waitForInFlight()` lets cleanup avoid racing an already-started send.
+
+- `refs/openclaw/src/channels/draft-stream-controls.ts`
+  - Wraps the loop with finalizable lifecycle state.
+  - Ignores updates after finalization.
+  - `stop()` marks final and forces a flush.
+  - `clear()` stops future updates, waits for in-flight work, then deletes or clears the preview.
+
+- `refs/openclaw/extensions/telegram/src/draft-stream.ts`
+  - Implements Telegram preview transport.
+  - Uses `DEFAULT_THROTTLE_MS = 1000`, clamped to at least `250ms`.
+  - Supports two transports:
+    - native `sendMessageDraft` where available
+    - fallback `sendMessage` followed by `editMessageText`
+  - Debounces the first preview with `minInitialChars`, but finalization bypasses this so a short final answer is still sent.
+  - Avoids duplicate edits by comparing rendered text and parse mode to the last sent value.
+  - Stops streaming if rendered text exceeds Telegram max length.
+  - Has `materialize()` to convert a draft preview into a permanent message, then clears stale draft text best-effort.
+  - Has `forceNewMessage()` to rotate preview state at assistant-message boundaries or tool boundaries.
+
+- `refs/openclaw/extensions/telegram/src/draft-chunking.ts`
+  - Telegram draft preview defaults are smaller than final message limits:
+    - `minChars = 200`
+    - `maxChars = 800`
+    - `breakPreference = "paragraph"`
+  - Config clamps preview max to the channel text limit.
+
+- `refs/openclaw/src/auto-reply/reply/block-reply-coalescer.ts`
+  - Closest match to an idle-flush buffer.
+  - Accumulates text payloads with a configured joiner.
+  - Schedules an idle timer after enqueue.
+  - On idle flush, it sends only when `bufferText.length >= minChars` unless forced.
+  - Flushes immediately when adding another payload would exceed `maxChars`.
+  - Flushes buffered text before media or metadata-conflicting payloads.
+  - `stop()` only clears the timer.
+
+- `refs/openclaw/src/auto-reply/reply/block-streaming.ts`
+  - Default block stream coalescing:
+    - `minChars = 800`
+    - `maxChars = 1200`
+    - `idleMs = 1000`
+  - ACP streaming overrides idle coalescing to `350ms` in `refs/openclaw/src/auto-reply/reply/acp-stream-settings.ts`.
+
+## Findings
+
+OpenClaw has timeout-flush heuristics, but not in a single simple writer identical to `acpella`'s `Reply.stream()`.
+
+There are two useful models:
+
+1. Draft preview loop:
+   - Better for editing or replacing one visible preview message.
+   - Sends a full snapshot of current text on a throttle interval.
+   - Needs lifecycle handling for finalization, clearing, in-flight sends, and stale previews.
+
+2. Block reply coalescer:
+   - Better fit for `acpella`'s append-only Telegram replies.
+   - Buffers text chunks and flushes after an idle timeout.
+   - Uses `minChars`, `maxChars`, and `idleMs` to avoid sending tiny updates too eagerly.
+
+For `acpella`, the block coalescer pattern is the safer first step. It does not require Telegram message editing, draft APIs, or materialization. A minimal version could add an idle timer to `createResponseWriter`:
+
+- `write(text)` appends to `bufferedText`
+- oversized text still flushes immediately using existing split logic
+- if buffer is non-empty and below limit, schedule idle flush
+- a new `write()` resets the idle timer
+- `flush()` and `finish()` clear the timer and flush synchronously
+- `finish()` should still send `(no response)` if nothing was ever sent
+- `stop`/cleanup support may be useful later if cancellation can abandon a writer with a live timer
+
+The draft/rewrite system is more ambitious. It may be worth revisiting only after append-only streaming is stable:
+
+- Telegram preview via `sendMessage`/`editMessageText` could reduce message spam.
+- Native `sendMessageDraft` is not generally available and needs fallback.
+- Preview finalization must avoid duplicate flashes and stale edits.
+- Race handling matters when a send is in flight and a new assistant message/tool boundary starts.
+
+## Implementation plan
+
+1. Keep current append-only `Reply.stream()` behavior as the baseline.
+2. Add optional writer config for idle coalescing:
+   - `idleMs`, likely `350ms` to `1000ms`
+   - `minChars`, likely small for `acpella` because Telegram replies are already user-visible final chunks
+3. Add fake-timer unit tests:
+   - coalesces writes inside idle window
+   - flushes after idle window
+   - does not idle-flush below `minChars`
+   - `finish()` cancels timer and flushes immediately
+   - oversized write still flushes immediately
+   - cancellation or cleanup clears timer if a stop API is added
+4. Defer draft/rewrite transport until there is a clear need to edit existing Telegram messages instead of sending append-only chunks.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -4,6 +4,10 @@
   - Keep sending Telegram chat action during long gaps where no text/tool updates are flushed
 - [ ] feat: reply stream idle flush
   - Flush buffered stream text after a short idle timeout when no follow-up write or finish arrives
+  - Notes: `docs/tasks/2026-04-14-openclaw-reply-streaming-notes.md`
+- [ ] refactor: reply split boundary heuristics
+  - Keep split heuristics independent from timeout flushing; split by size immediately, then use paragraph/line/space thresholds for readable chunk boundaries
+  - Notes: `docs/tasks/2026-04-14-openclaw-reply-streaming-notes.md`
 - [ ] feat: telegram Markdown formatting (Telegram MarkdownV2)
 - [ ] feat: session lifecycle
   - [ ] Daily refresh — close and recreate session at configurable hour

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -4,8 +4,6 @@
   - Keep sending Telegram chat action during long gaps where no text/tool updates are flushed
 - [ ] feat: reply stream idle flush
   - Flush buffered stream text after a short idle timeout when no follow-up write or finish arrives
-- [ ] refactor: reply split boundary heuristics
-  - Use boundary-specific thresholds: paragraph breaks can produce smaller chunks, line breaks should be moderately full, and spaces should be close to the limit before splitting
 - [ ] feat: telegram Markdown formatting (Telegram MarkdownV2)
 - [ ] feat: session lifecycle
   - [ ] Daily refresh — close and recreate session at configurable hour

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -2,6 +2,10 @@
 
 - [ ] feat: telegram Typing indicator while agent is working
   - Keep sending Telegram chat action during long gaps where no text/tool updates are flushed
+- [ ] feat: reply stream idle flush
+  - Flush buffered stream text after a short idle timeout when no follow-up write or finish arrives
+- [ ] refactor: reply split boundary heuristics
+  - Use boundary-specific thresholds: paragraph breaks can produce smaller chunks, line breaks should be moderately full, and spaces should be close to the limit before splitting
 - [ ] feat: telegram Markdown formatting (Telegram MarkdownV2)
 - [ ] feat: session lifecycle
   - [ ] Daily refresh — close and recreate session at configurable hour

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -1,19 +1,14 @@
 import fs from "node:fs";
+import type { Context } from "grammy";
 import { startAcpManager } from "./acp/index.ts";
 import type { AgentSession } from "./acp/index.ts";
 import type { AppConfig } from "./config.ts";
 import { createReply, MESSAGE_SPLIT_BUDGET } from "./lib/reply.ts";
-import type { Reply, ReplyContext } from "./lib/reply.ts";
+import type { Reply } from "./lib/reply.ts";
 import { createSessionStateStore } from "./state.ts";
 
-interface HandlerContext extends ReplyContext {
-  message: {
-    text: string;
-  };
-}
-
 interface Handler {
-  handle: (options: { session: string; context: HandlerContext }) => Promise<void>;
+  handle: (options: { session: string; context: Context }) => Promise<void>;
 }
 
 export async function createHandler(
@@ -259,7 +254,7 @@ prompt file: ${config.prompt.file ?? "none"}`;
   }
 
   const handle: Handler["handle"] = async (options) => {
-    const text = options.context.message.text;
+    const text = options.context.message!.text!;
     const sessionName = options.session;
     const reply = createReply({
       context: options.context,

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -1,21 +1,19 @@
 import fs from "node:fs";
-import type { Context } from "grammy";
 import { startAcpManager } from "./acp/index.ts";
 import type { AgentSession } from "./acp/index.ts";
 import type { AppConfig } from "./config.ts";
+import { createReply, MESSAGE_SPLIT_BUDGET } from "./lib/reply.ts";
+import type { Reply, ReplyContext } from "./lib/reply.ts";
 import { createSessionStateStore } from "./state.ts";
 
-const MESSAGE_SPLIT_BUDGET = 3900;
-
-interface Reply {
-  send: (text: string, options?: { system?: boolean }) => Promise<void>;
-  stream: () => ResponseWriter;
+interface HandlerContext extends ReplyContext {
+  message: {
+    text: string;
+  };
 }
 
-interface ResponseWriter {
-  write: (text: string) => Promise<void>;
-  flush: () => Promise<void>;
-  finish: () => Promise<void>;
+interface Handler {
+  handle: (options: { session: string; context: HandlerContext }) => Promise<void>;
 }
 
 export async function createHandler(
@@ -23,9 +21,7 @@ export async function createHandler(
   options: {
     onServiceExit: () => void;
   },
-): Promise<{
-  handle: (options: { session: string; context: Context }) => Promise<void>;
-}> {
+): Promise<Handler> {
   const manager = await startAcpManager({ command: config.agent.command, cwd: config.home });
   const state = createSessionStateStore(config);
   const activeSessions = new Map<string, AgentSession>();
@@ -264,8 +260,8 @@ state file: ${config.stateFile}
 prompt file: ${config.prompt.file ?? "none"}`;
   }
 
-  const handle = async (options: { session: string; context: Context }): Promise<void> => {
-    const text = options.context.message!.text!;
+  const handle: Handler["handle"] = async (options) => {
+    const text = options.context.message.text;
     const sessionName = options.session;
     const reply = createReply({
       context: options.context,
@@ -335,112 +331,4 @@ function readOptionalPromptFile(file: string): string | undefined {
 
 function isNodeError(error: unknown): error is NodeJS.ErrnoException {
   return error instanceof Error && "code" in error;
-}
-
-function createReply(options: { context: Context; limit: number }): Reply {
-  async function send(text: string, sendOptions: { system?: boolean } = {}): Promise<void> {
-    const responseText = sendOptions.system ? `⚙️ ${text}` : text;
-    const parts = splitMessageText(responseText, options.limit);
-    for (const part of parts) {
-      await options.context.reply(part);
-    }
-  }
-
-  return {
-    send,
-    stream() {
-      return createResponseWriter({
-        limit: options.limit,
-        send,
-      });
-    },
-  };
-}
-
-function splitMessageText(text: string, limit: number): string[] {
-  const parts: string[] = [];
-  let remaining = text.trim();
-  while (remaining.length > limit) {
-    const result = splitHead(remaining, limit);
-    const part = result.head.trim();
-    if (part) {
-      parts.push(part);
-    }
-    remaining = result.tail.trim();
-  }
-  if (remaining) {
-    parts.push(remaining);
-  }
-  return parts;
-}
-
-function findSplitIndex(text: string, budget: number): number {
-  const paragraphIndex = text.lastIndexOf("\n\n", budget);
-  if (paragraphIndex > budget / 2) {
-    return paragraphIndex + 2;
-  }
-  const lineIndex = text.lastIndexOf("\n", budget);
-  if (lineIndex > budget / 2) {
-    return lineIndex + 1;
-  }
-  const spaceIndex = text.lastIndexOf(" ", budget);
-  if (spaceIndex > budget / 2) {
-    return spaceIndex + 1;
-  }
-  return budget;
-}
-
-function createResponseWriter(options: {
-  limit: number;
-  send: (text: string) => Promise<void>;
-}): ResponseWriter {
-  let bufferedText = "";
-  let sentResponse = false;
-
-  async function send(text: string): Promise<void> {
-    await options.send(text);
-    sentResponse = true;
-  }
-
-  async function flush(): Promise<void> {
-    if (!bufferedText.trim()) {
-      bufferedText = "";
-      return;
-    }
-    await send(bufferedText);
-    bufferedText = "";
-  }
-
-  async function flushOversizedText(): Promise<void> {
-    while (bufferedText.length > options.limit) {
-      const result = splitHead(bufferedText, options.limit);
-      bufferedText = result.tail;
-      const part = result.head.trim();
-      if (part) {
-        await send(part);
-      }
-    }
-  }
-
-  return {
-    async write(text: string): Promise<void> {
-      bufferedText += text;
-      await flushOversizedText();
-    },
-    flush,
-    async finish(): Promise<void> {
-      await flush();
-      if (!sentResponse) {
-        await send("(no response)");
-      }
-    },
-  };
-}
-
-function splitHead(text: string, limit: number): { head: string; tail: string } {
-  const splitIndex = findSplitIndex(text, limit);
-  return {
-    head: text.slice(0, splitIndex),
-    tail: text.slice(splitIndex),
-  };
 }

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -34,9 +34,7 @@ export async function createHandler(
     sessionId?: string;
   }): Promise<void> {
     if (activeSessions.has(options.name)) {
-      await options.reply.send("Agent turn already in progress. Send /cancel to stop it.", {
-        system: true,
-      });
+      await options.reply.system("Agent turn already in progress. Send /cancel to stop it.");
       return;
     }
 
@@ -56,27 +54,27 @@ export async function createHandler(
         : options.text;
 
       const { queue } = session.prompt(promptText);
-      const responseWriter = options.reply.stream();
+      const replyStream = options.reply.stream();
       activeSessions.set(options.name, session);
 
       for await (const update of queue) {
         if (update.sessionUpdate === "agent_message_chunk" && update.content.type === "text") {
-          await responseWriter.write(update.content.text);
+          await replyStream.write(update.content.text);
         } else if (update.sessionUpdate === "tool_call") {
           console.log(`[acp:update] tool_call: ${update.title}`);
-          await responseWriter.flush();
-          await responseWriter.write(`Tool: ${update.title}`);
-          await responseWriter.flush();
+          await replyStream.flush();
+          await replyStream.write(`Tool: ${update.title}`);
+          await replyStream.flush();
         } else {
           console.log(`[acp:update] ${update.sessionUpdate}`);
         }
       }
       if (cancelledSessions.has(session)) {
-        await responseWriter.flush();
-        await options.reply.send("Agent turn cancelled.", { system: true });
+        await replyStream.flush();
+        await options.reply.system("Agent turn cancelled.");
         return;
       }
-      await responseWriter.finish();
+      await replyStream.finish();
       if (!options.sessionId) {
         state.setSessionId(options.name, session.sessionId);
       }
@@ -91,7 +89,7 @@ export async function createHandler(
   async function handleCancel(options: { reply: Reply; sessionName: string }): Promise<void> {
     const session = activeSessions.get(options.sessionName);
     if (!session) {
-      await options.reply.send("No active agent turn.", { system: true });
+      await options.reply.system("No active agent turn.");
       return;
     }
 
@@ -104,7 +102,7 @@ export async function createHandler(
       session.close();
       response = "Cancelled current agent turn by killing the agent process.";
     }
-    await options.reply.send(response, { system: true });
+    await options.reply.system(response);
   }
 
   async function handleCloseSession(options: {
@@ -229,7 +227,7 @@ Usage:
 /session load <sessionId>
 /session close [sessionId]`;
     }
-    await options.reply.send(response, { system: true });
+    await options.reply.system(response);
     return true;
   }
 
@@ -242,11 +240,11 @@ Usage:
       return false;
     }
     if (subcommand === "exit") {
-      await commandOptions.reply.send("Exiting acpella.", { system: true });
+      await commandOptions.reply.system("Exiting acpella.");
       options.onServiceExit();
       return true;
     }
-    await commandOptions.reply.send("Usage: /service exit", { system: true });
+    await commandOptions.reply.system("Usage: /service exit");
     return true;
   }
 
@@ -269,7 +267,7 @@ prompt file: ${config.prompt.file ?? "none"}`;
     });
 
     if (text === "/status") {
-      await reply.send(handleStatus(), { system: true });
+      await reply.system(handleStatus());
       return;
     }
     if (text === "/cancel") {

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -28,8 +28,9 @@ export async function createHandler(
     text: string;
     sessionId?: string;
   }): Promise<void> {
+    const { reply } = options;
     if (activeSessions.has(options.name)) {
-      await options.reply.system("Agent turn already in progress. Send /cancel to stop it.");
+      await reply.system("Agent turn already in progress. Send /cancel to stop it.");
       return;
     }
 
@@ -49,27 +50,26 @@ export async function createHandler(
         : options.text;
 
       const { queue } = session.prompt(promptText);
-      const replyStream = options.reply.stream();
       activeSessions.set(options.name, session);
 
       for await (const update of queue) {
         if (update.sessionUpdate === "agent_message_chunk" && update.content.type === "text") {
-          await replyStream.write(update.content.text);
+          await reply.write(update.content.text);
         } else if (update.sessionUpdate === "tool_call") {
           console.log(`[acp:update] tool_call: ${update.title}`);
-          await replyStream.flush();
-          await replyStream.write(`Tool: ${update.title}`);
-          await replyStream.flush();
+          await reply.flush();
+          await reply.write(`Tool: ${update.title}`);
+          await reply.flush();
         } else {
           console.log(`[acp:update] ${update.sessionUpdate}`);
         }
       }
       if (cancelledSessions.has(session)) {
-        await replyStream.flush();
-        await options.reply.system("Agent turn cancelled.");
+        await reply.flush();
+        await reply.system("Agent turn cancelled.");
         return;
       }
-      await replyStream.finish();
+      await reply.finish();
       if (!options.sessionId) {
         state.setSessionId(options.name, session.sessionId);
       }

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -13,6 +13,17 @@ interface StateSession {
   sessionId: string;
 }
 
+interface Reply {
+  send: (text: string, options?: { system?: boolean }) => Promise<void>;
+  stream: () => ResponseWriter;
+}
+
+interface ResponseWriter {
+  write: (text: string) => Promise<void>;
+  flush: () => Promise<void>;
+  finish: () => Promise<void>;
+}
+
 export async function createHandler(
   config: AppConfig,
   options: {
@@ -27,16 +38,14 @@ export async function createHandler(
   const cancelledSessions = new WeakSet<AgentSession>();
 
   async function handlePrompt(options: {
-    context: Context;
+    reply: Reply;
     name: string;
     text: string;
     sessionId?: string;
   }): Promise<void> {
     if (activeSessions.has(options.name)) {
-      await sendSystemResponse({
-        context: options.context,
-        limit: MESSAGE_SPLIT_BUDGET,
-        text: "Agent turn already in progress. Send /cancel to stop it.",
+      await options.reply.send("Agent turn already in progress. Send /cancel to stop it.", {
+        system: true,
       });
       return;
     }
@@ -57,10 +66,7 @@ export async function createHandler(
         : options.text;
 
       const { queue } = session.prompt(promptText);
-      const responseWriter = createResponseWriter({
-        context: options.context,
-        limit: MESSAGE_SPLIT_BUDGET,
-      });
+      const responseWriter = options.reply.stream();
       activeSessions.set(options.name, session);
 
       for await (const update of queue) {
@@ -77,11 +83,7 @@ export async function createHandler(
       }
       if (cancelledSessions.has(session)) {
         await responseWriter.flush();
-        await sendSystemResponse({
-          context: options.context,
-          limit: MESSAGE_SPLIT_BUDGET,
-          text: "Agent turn cancelled.",
-        });
+        await options.reply.send("Agent turn cancelled.", { system: true });
         return;
       }
       await responseWriter.finish();
@@ -96,14 +98,10 @@ export async function createHandler(
     }
   }
 
-  async function handleCancel(options: { context: Context; sessionName: string }): Promise<void> {
+  async function handleCancel(options: { reply: Reply; sessionName: string }): Promise<void> {
     const session = activeSessions.get(options.sessionName);
     if (!session) {
-      await sendSystemResponse({
-        context: options.context,
-        limit: MESSAGE_SPLIT_BUDGET,
-        text: "No active agent turn.",
-      });
+      await options.reply.send("No active agent turn.", { system: true });
       return;
     }
 
@@ -116,11 +114,7 @@ export async function createHandler(
       session.close();
       response = "Cancelled current agent turn by killing the agent process.";
     }
-    await sendSystemResponse({
-      context: options.context,
-      limit: MESSAGE_SPLIT_BUDGET,
-      text: response,
-    });
+    await options.reply.send(response, { system: true });
   }
 
   async function handleCloseSession(options: {
@@ -142,12 +136,12 @@ export async function createHandler(
   }
 
   async function handleNewSession(options: {
-    context: Context;
+    reply: Reply;
     name: string;
     text: string;
   }): Promise<void> {
     return handlePrompt({
-      context: options.context,
+      reply: options.reply,
       name: options.name,
       text: options.text,
     });
@@ -203,7 +197,7 @@ ${formatAgentSessions({ sessions: untrackedAgentSessions }).join("\n")}`;
   }
 
   async function handleSessionCommand(options: {
-    context: Context;
+    reply: Reply;
     text: string;
     sessionName: string;
   }): Promise<boolean> {
@@ -221,7 +215,7 @@ ${formatAgentSessions({ sessions: untrackedAgentSessions }).join("\n")}`;
         break;
       case "new":
         await handleNewSession({
-          context: options.context,
+          reply: options.reply,
           name: options.sessionName,
           text: args.join(" "),
         });
@@ -248,16 +242,12 @@ Usage:
 /session load <sessionId>
 /session close [sessionId]`;
     }
-    await sendSystemResponse({
-      context: options.context,
-      limit: MESSAGE_SPLIT_BUDGET,
-      text: response,
-    });
+    await options.reply.send(response, { system: true });
     return true;
   }
 
   async function handleServiceCommand(commandOptions: {
-    context: Context;
+    reply: Reply;
     text: string;
   }): Promise<boolean> {
     const [command, subcommand] = commandOptions.text.trim().split(/\s+/);
@@ -265,19 +255,11 @@ Usage:
       return false;
     }
     if (subcommand === "exit") {
-      await sendSystemResponse({
-        context: commandOptions.context,
-        limit: MESSAGE_SPLIT_BUDGET,
-        text: "Exiting acpella.",
-      });
+      await commandOptions.reply.send("Exiting acpella.", { system: true });
       options.onServiceExit();
       return true;
     }
-    await sendSystemResponse({
-      context: commandOptions.context,
-      limit: MESSAGE_SPLIT_BUDGET,
-      text: "Usage: /service exit",
-    });
+    await commandOptions.reply.send("Usage: /service exit", { system: true });
     return true;
   }
 
@@ -294,31 +276,31 @@ prompt file: ${config.prompt.file ?? "none"}`;
   const handle = async (options: { session: string; context: Context }): Promise<void> => {
     const text = options.context.message!.text!;
     const sessionName = options.session;
+    const reply = createReply({
+      context: options.context,
+      limit: MESSAGE_SPLIT_BUDGET,
+    });
 
     if (text === "/status") {
-      await sendSystemResponse({
-        context: options.context,
-        limit: MESSAGE_SPLIT_BUDGET,
-        text: handleStatus(),
-      });
+      await reply.send(handleStatus(), { system: true });
       return;
     }
     if (text === "/cancel") {
       await handleCancel({
-        context: options.context,
+        reply,
         sessionName,
       });
       return;
     }
     const handledServiceCommand = await handleServiceCommand({
-      context: options.context,
+      reply,
       text,
     });
     if (handledServiceCommand) {
       return;
     }
     const handledSessionCommand = await handleSessionCommand({
-      context: options.context,
+      reply,
       text,
       sessionName,
     });
@@ -327,7 +309,7 @@ prompt file: ${config.prompt.file ?? "none"}`;
     }
 
     await handlePrompt({
-      context: options.context,
+      reply,
       name: sessionName,
       text,
       sessionId: state.getSessionId(sessionName),
@@ -387,27 +369,24 @@ function isNodeError(error: unknown): error is NodeJS.ErrnoException {
   return error instanceof Error && "code" in error;
 }
 
-async function sendTextResponse(options: {
-  context: Context;
-  limit: number;
-  text: string;
-}): Promise<void> {
-  const parts = splitMessageText(options.text, options.limit);
-  for (const part of parts) {
-    await options.context.reply(part);
+function createReply(options: { context: Context; limit: number }): Reply {
+  async function send(text: string, sendOptions: { system?: boolean } = {}): Promise<void> {
+    const responseText = sendOptions.system ? `⚙️ ${text}` : text;
+    const parts = splitMessageText(responseText, options.limit);
+    for (const part of parts) {
+      await options.context.reply(part);
+    }
   }
-}
 
-async function sendSystemResponse(options: {
-  context: Context;
-  limit: number;
-  text: string;
-}): Promise<void> {
-  await sendTextResponse({
-    context: options.context,
-    limit: options.limit,
-    text: `⚙️ ${options.text}`,
-  });
+  return {
+    send,
+    stream() {
+      return createResponseWriter({
+        limit: options.limit,
+        send,
+      });
+    },
+  };
 }
 
 function splitMessageText(text: string, limit: number): string[] {
@@ -443,16 +422,15 @@ function findSplitIndex(text: string, budget: number): number {
   return budget;
 }
 
-function createResponseWriter(options: { context: Context; limit: number }) {
+function createResponseWriter(options: {
+  limit: number;
+  send: (text: string) => Promise<void>;
+}): ResponseWriter {
   let bufferedText = "";
   let sentResponse = false;
 
   async function send(text: string): Promise<void> {
-    await sendTextResponse({
-      context: options.context,
-      limit: options.limit,
-      text,
-    });
+    await options.send(text);
     sentResponse = true;
   }
 
@@ -485,7 +463,7 @@ function createResponseWriter(options: { context: Context; limit: number }) {
     async finish(): Promise<void> {
       await flush();
       if (!sentResponse) {
-        await options.context.reply("(no response)");
+        await send("(no response)");
       }
     },
   };

--- a/src/lib/reply.test.ts
+++ b/src/lib/reply.test.ts
@@ -47,14 +47,13 @@ describe(createReply, () => {
     `);
   });
 
-  it("buffers stream chunks until finish", async () => {
+  it("buffers chunks until finish", async () => {
     const { reply, messages } = createReplyTest({ limit: 100 });
-    const stream = reply.stream();
-    await stream.write("hel");
+    await reply.write("hel");
     expect(messages).toMatchInlineSnapshot(`[]`);
-    await stream.write("lo");
+    await reply.write("lo");
     expect(messages).toMatchInlineSnapshot(`[]`);
-    await stream.finish();
+    await reply.finish();
     expect(messages).toMatchInlineSnapshot(`
       [
         "hello",
@@ -62,24 +61,23 @@ describe(createReply, () => {
     `);
   });
 
-  it("flushes buffered stream text early", async () => {
+  it("flushes buffered text early", async () => {
     const { reply, messages } = createReplyTest({ limit: 100 });
-    const stream = reply.stream();
-    await stream.write("Tool: abc");
+    await reply.write("Tool: abc");
     expect(messages).toMatchInlineSnapshot(`[]`);
-    await stream.flush();
+    await reply.flush();
     expect(messages).toMatchInlineSnapshot(`
       [
         "Tool: abc",
       ]
     `);
-    await stream.write("done");
+    await reply.write("done");
     expect(messages).toMatchInlineSnapshot(`
       [
         "Tool: abc",
       ]
     `);
-    await stream.finish();
+    await reply.finish();
     expect(messages).toMatchInlineSnapshot(`
       [
         "Tool: abc",
@@ -88,16 +86,15 @@ describe(createReply, () => {
     `);
   });
 
-  it("flushes oversized stream text during write", async () => {
+  it("flushes oversized text during write", async () => {
     const { reply, messages } = createReplyTest({ limit: 20 });
-    const stream = reply.stream();
-    await stream.write("alpha beta gamma delta");
+    await reply.write("alpha beta gamma delta");
     expect(messages).toMatchInlineSnapshot(`
       [
         "alpha beta gamma",
       ]
     `);
-    await stream.finish();
+    await reply.finish();
     expect(messages).toMatchInlineSnapshot(`
       [
         "alpha beta gamma",
@@ -106,35 +103,17 @@ describe(createReply, () => {
     `);
   });
 
-  it("does not send fallback after flushed stream text", async () => {
+  it("does not send fallback after flushed text", async () => {
     const { reply, messages } = createReplyTest({ limit: 100 });
-    const stream = reply.stream();
-    await stream.write("hello");
+    await reply.write("hello");
     expect(messages).toMatchInlineSnapshot(`[]`);
-    await stream.flush();
+    await reply.flush();
     expect(messages).toMatchInlineSnapshot(`
       [
         "hello",
       ]
     `);
-    await stream.finish();
-    expect(messages).toMatchInlineSnapshot(`
-      [
-        "hello",
-      ]
-    `);
-  });
-
-  it("clears blank stream text on flush", async () => {
-    const { reply, messages } = createReplyTest({ limit: 100 });
-    const stream = reply.stream();
-    await stream.write("   ");
-    expect(messages).toMatchInlineSnapshot(`[]`);
-    await stream.flush();
-    expect(messages).toMatchInlineSnapshot(`[]`);
-    await stream.write("hello");
-    expect(messages).toMatchInlineSnapshot(`[]`);
-    await stream.finish();
+    await reply.finish();
     expect(messages).toMatchInlineSnapshot(`
       [
         "hello",
@@ -142,10 +121,25 @@ describe(createReply, () => {
     `);
   });
 
-  it("sends no response fallback when stream finishes empty", async () => {
+  it("clears blank text on flush", async () => {
     const { reply, messages } = createReplyTest({ limit: 100 });
-    const stream = reply.stream();
-    await stream.finish();
+    await reply.write("   ");
+    expect(messages).toMatchInlineSnapshot(`[]`);
+    await reply.flush();
+    expect(messages).toMatchInlineSnapshot(`[]`);
+    await reply.write("hello");
+    expect(messages).toMatchInlineSnapshot(`[]`);
+    await reply.finish();
+    expect(messages).toMatchInlineSnapshot(`
+      [
+        "hello",
+      ]
+    `);
+  });
+
+  it("sends no response fallback when reply finishes empty", async () => {
+    const { reply, messages } = createReplyTest({ limit: 100 });
+    await reply.finish();
     expect(messages).toMatchInlineSnapshot(`
       [
         "(no response)",

--- a/src/lib/reply.test.ts
+++ b/src/lib/reply.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { createReply } from "./reply.ts";
+
+function createReplyTest(options: { limit: number }) {
+  const messages: string[] = [];
+  const reply = createReply({
+    context: {
+      async reply(text: string): Promise<void> {
+        messages.push(text);
+      },
+    },
+    limit: options.limit,
+  });
+  return { reply, messages };
+}
+
+describe(createReply, () => {
+  it("sends short text as-is", async () => {
+    const { reply, messages } = createReplyTest({ limit: 100 });
+    await reply.send("hello");
+    expect(messages).toMatchInlineSnapshot(`
+      [
+        "hello",
+      ]
+    `);
+  });
+
+  it("splits long text without exceeding the limit", async () => {
+    const { reply, messages } = createReplyTest({ limit: 20 });
+    await reply.send("alpha beta gamma delta");
+    expect(messages).toMatchInlineSnapshot(`
+      [
+        "alpha beta gamma",
+        "delta",
+      ]
+    `);
+  });
+});

--- a/src/lib/reply.test.ts
+++ b/src/lib/reply.test.ts
@@ -35,4 +35,121 @@ describe(createReply, () => {
       ]
     `);
   });
+
+  it("sends system text with a system prefix", async () => {
+    const { reply, messages } = createReplyTest({ limit: 100 });
+    await reply.system("Status ok");
+    expect(messages).toMatchInlineSnapshot(`
+      [
+        "[⚙️ System]
+      Status ok",
+      ]
+    `);
+  });
+
+  it("buffers stream chunks until finish", async () => {
+    const { reply, messages } = createReplyTest({ limit: 100 });
+    const stream = reply.stream();
+    await stream.write("hel");
+    expect(messages).toMatchInlineSnapshot(`[]`);
+    await stream.write("lo");
+    expect(messages).toMatchInlineSnapshot(`[]`);
+    await stream.finish();
+    expect(messages).toMatchInlineSnapshot(`
+      [
+        "hello",
+      ]
+    `);
+  });
+
+  it("flushes buffered stream text early", async () => {
+    const { reply, messages } = createReplyTest({ limit: 100 });
+    const stream = reply.stream();
+    await stream.write("Tool: abc");
+    expect(messages).toMatchInlineSnapshot(`[]`);
+    await stream.flush();
+    expect(messages).toMatchInlineSnapshot(`
+      [
+        "Tool: abc",
+      ]
+    `);
+    await stream.write("done");
+    expect(messages).toMatchInlineSnapshot(`
+      [
+        "Tool: abc",
+      ]
+    `);
+    await stream.finish();
+    expect(messages).toMatchInlineSnapshot(`
+      [
+        "Tool: abc",
+        "done",
+      ]
+    `);
+  });
+
+  it("flushes oversized stream text during write", async () => {
+    const { reply, messages } = createReplyTest({ limit: 20 });
+    const stream = reply.stream();
+    await stream.write("alpha beta gamma delta");
+    expect(messages).toMatchInlineSnapshot(`
+      [
+        "alpha beta gamma",
+      ]
+    `);
+    await stream.finish();
+    expect(messages).toMatchInlineSnapshot(`
+      [
+        "alpha beta gamma",
+        "delta",
+      ]
+    `);
+  });
+
+  it("does not send fallback after flushed stream text", async () => {
+    const { reply, messages } = createReplyTest({ limit: 100 });
+    const stream = reply.stream();
+    await stream.write("hello");
+    expect(messages).toMatchInlineSnapshot(`[]`);
+    await stream.flush();
+    expect(messages).toMatchInlineSnapshot(`
+      [
+        "hello",
+      ]
+    `);
+    await stream.finish();
+    expect(messages).toMatchInlineSnapshot(`
+      [
+        "hello",
+      ]
+    `);
+  });
+
+  it("clears blank stream text on flush", async () => {
+    const { reply, messages } = createReplyTest({ limit: 100 });
+    const stream = reply.stream();
+    await stream.write("   ");
+    expect(messages).toMatchInlineSnapshot(`[]`);
+    await stream.flush();
+    expect(messages).toMatchInlineSnapshot(`[]`);
+    await stream.write("hello");
+    expect(messages).toMatchInlineSnapshot(`[]`);
+    await stream.finish();
+    expect(messages).toMatchInlineSnapshot(`
+      [
+        "hello",
+      ]
+    `);
+  });
+
+  it("sends no response fallback when stream finishes empty", async () => {
+    const { reply, messages } = createReplyTest({ limit: 100 });
+    const stream = reply.stream();
+    await stream.finish();
+    expect(messages).toMatchInlineSnapshot(`
+      [
+        "(no response)",
+      ]
+    `);
+  });
 });

--- a/src/lib/reply.ts
+++ b/src/lib/reply.ts
@@ -47,6 +47,13 @@ function splitMessageText(text: string, limit: number): string[] {
 }
 
 function findSplitIndex(text: string, limit: number): number {
+  // Split at the best available natural boundary before the limit:
+  // paragraph break first, then line break, then word space. If none are
+  // found, hard-split at the limit. The boundary must be in the latter half
+  // of the chunk so we do not send tiny leading fragments just to preserve a
+  // very early separator.
+  // TODO: should divions heuristics adjusted based on splitter?
+  // e.g. paragraph split can be more chunkier.
   const paragraphIndex = text.lastIndexOf("\n\n", limit);
   if (paragraphIndex > limit / 2) {
     return paragraphIndex + 2;

--- a/src/lib/reply.ts
+++ b/src/lib/reply.ts
@@ -1,0 +1,124 @@
+export const MESSAGE_SPLIT_BUDGET = 3900;
+
+export interface ReplyContext {
+  reply: (text: string) => Promise<unknown>;
+}
+
+export interface Reply {
+  send: (text: string, options?: { system?: boolean }) => Promise<void>;
+  stream: () => ResponseWriter;
+}
+
+interface ResponseWriter {
+  write: (text: string) => Promise<void>;
+  flush: () => Promise<void>;
+  finish: () => Promise<void>;
+}
+
+export function createReply(options: { context: ReplyContext; limit: number }): Reply {
+  async function send(text: string, sendOptions: { system?: boolean } = {}): Promise<void> {
+    const responseText = sendOptions.system ? `⚙️ ${text}` : text;
+    const parts = splitMessageText(responseText, options.limit);
+    for (const part of parts) {
+      await options.context.reply(part);
+    }
+  }
+
+  return {
+    send,
+    stream() {
+      return createResponseWriter({
+        limit: options.limit,
+        send,
+      });
+    },
+  };
+}
+
+function splitMessageText(text: string, limit: number): string[] {
+  const parts: string[] = [];
+  let remaining = text.trim();
+  while (remaining.length > limit) {
+    const result = splitHead(remaining, limit);
+    const part = result.head.trim();
+    if (part) {
+      parts.push(part);
+    }
+    remaining = result.tail.trim();
+  }
+  if (remaining) {
+    parts.push(remaining);
+  }
+  return parts;
+}
+
+function findSplitIndex(text: string, budget: number): number {
+  const paragraphIndex = text.lastIndexOf("\n\n", budget);
+  if (paragraphIndex > budget / 2) {
+    return paragraphIndex + 2;
+  }
+  const lineIndex = text.lastIndexOf("\n", budget);
+  if (lineIndex > budget / 2) {
+    return lineIndex + 1;
+  }
+  const spaceIndex = text.lastIndexOf(" ", budget);
+  if (spaceIndex > budget / 2) {
+    return spaceIndex + 1;
+  }
+  return budget;
+}
+
+function createResponseWriter(options: {
+  limit: number;
+  send: (text: string) => Promise<void>;
+}): ResponseWriter {
+  let bufferedText = "";
+  let sentResponse = false;
+
+  async function send(text: string): Promise<void> {
+    await options.send(text);
+    sentResponse = true;
+  }
+
+  async function flush(): Promise<void> {
+    if (!bufferedText.trim()) {
+      bufferedText = "";
+      return;
+    }
+    await send(bufferedText);
+    bufferedText = "";
+  }
+
+  async function flushOversizedText(): Promise<void> {
+    while (bufferedText.length > options.limit) {
+      const result = splitHead(bufferedText, options.limit);
+      bufferedText = result.tail;
+      const part = result.head.trim();
+      if (part) {
+        await send(part);
+      }
+    }
+  }
+
+  return {
+    async write(text: string): Promise<void> {
+      bufferedText += text;
+      await flushOversizedText();
+    },
+    flush,
+    async finish(): Promise<void> {
+      await flush();
+      if (!sentResponse) {
+        await send("(no response)");
+      }
+    },
+  };
+}
+
+function splitHead(text: string, limit: number): { head: string; tail: string } {
+  const splitIndex = findSplitIndex(text, limit);
+  return {
+    head: text.slice(0, splitIndex),
+    tail: text.slice(splitIndex),
+  };
+}

--- a/src/lib/reply.ts
+++ b/src/lib/reply.ts
@@ -5,7 +5,8 @@ export interface ReplyContext {
 }
 
 export interface Reply {
-  send: (text: string, options?: { system?: boolean }) => Promise<void>;
+  send: (text: string) => Promise<void>;
+  system: (text: string) => Promise<void>;
   stream: () => ResponseWriter;
 }
 
@@ -16,9 +17,8 @@ interface ResponseWriter {
 }
 
 export function createReply(options: { context: ReplyContext; limit: number }): Reply {
-  async function send(text: string, sendOptions: { system?: boolean } = {}): Promise<void> {
-    const responseText = sendOptions.system ? `⚙️ ${text}` : text;
-    const parts = splitMessageText(responseText, options.limit);
+  async function send(text: string): Promise<void> {
+    const parts = splitMessageText(text, options.limit);
     for (const part of parts) {
       await options.context.reply(part);
     }
@@ -26,6 +26,9 @@ export function createReply(options: { context: ReplyContext; limit: number }): 
 
   return {
     send,
+    system(text: string) {
+      return send(`[⚙️ System]\n${text}`);
+    },
     stream() {
       return createResponseWriter({
         limit: options.limit,
@@ -52,20 +55,20 @@ function splitMessageText(text: string, limit: number): string[] {
   return parts;
 }
 
-function findSplitIndex(text: string, budget: number): number {
-  const paragraphIndex = text.lastIndexOf("\n\n", budget);
-  if (paragraphIndex > budget / 2) {
+function findSplitIndex(text: string, limit: number): number {
+  const paragraphIndex = text.lastIndexOf("\n\n", limit);
+  if (paragraphIndex > limit / 2) {
     return paragraphIndex + 2;
   }
-  const lineIndex = text.lastIndexOf("\n", budget);
-  if (lineIndex > budget / 2) {
+  const lineIndex = text.lastIndexOf("\n", limit);
+  if (lineIndex > limit / 2) {
     return lineIndex + 1;
   }
-  const spaceIndex = text.lastIndexOf(" ", budget);
-  if (spaceIndex > budget / 2) {
+  const spaceIndex = text.lastIndexOf(" ", limit);
+  if (spaceIndex > limit / 2) {
     return spaceIndex + 1;
   }
-  return budget;
+  return limit;
 }
 
 function createResponseWriter(options: {

--- a/src/lib/reply.ts
+++ b/src/lib/reply.ts
@@ -8,10 +8,42 @@ export interface ReplyContext {
 export type Reply = ReturnType<typeof createReply>;
 
 export function createReply(options: { context: ReplyContext; limit: number }) {
+  let buffer = "";
+  let sent = false;
+
   async function send(text: string): Promise<void> {
     const parts = splitMessageText(text, options.limit);
     for (const part of parts) {
       await options.context.reply(part);
+    }
+    sent = true;
+  }
+
+  async function flush(): Promise<void> {
+    if (!buffer.trim()) {
+      buffer = "";
+      return;
+    }
+    await send(buffer);
+    buffer = "";
+  }
+
+  async function write(text: string): Promise<void> {
+    buffer += text;
+    while (buffer.length > options.limit) {
+      const result = splitHead(buffer, options.limit);
+      buffer = result.tail;
+      const part = result.head.trim();
+      if (part) {
+        await send(part);
+      }
+    }
+  }
+
+  async function finish() {
+    await flush();
+    if (!sent) {
+      await send("(no response)");
     }
   }
 
@@ -20,11 +52,11 @@ export function createReply(options: { context: ReplyContext; limit: number }) {
     system(text: string) {
       return send(`[⚙️ System]\n${text}`);
     },
+    write,
+    flush,
+    finish,
     stream() {
-      return createResponseWriter({
-        limit: options.limit,
-        send,
-      });
+      return this;
     },
   };
 }
@@ -65,50 +97,6 @@ function findSplitIndex(text: string, limit: number): number {
     }
   }
   return limit;
-}
-
-function createResponseWriter(options: { limit: number; send: (text: string) => Promise<void> }) {
-  let bufferedText = "";
-  let sentResponse = false;
-
-  async function send(text: string): Promise<void> {
-    await options.send(text);
-    sentResponse = true;
-  }
-
-  async function flush(): Promise<void> {
-    if (!bufferedText.trim()) {
-      bufferedText = "";
-      return;
-    }
-    await send(bufferedText);
-    bufferedText = "";
-  }
-
-  async function flushOversizedText(): Promise<void> {
-    while (bufferedText.length > options.limit) {
-      const result = splitHead(bufferedText, options.limit);
-      bufferedText = result.tail;
-      const part = result.head.trim();
-      if (part) {
-        await send(part);
-      }
-    }
-  }
-
-  return {
-    async write(text: string): Promise<void> {
-      bufferedText += text;
-      await flushOversizedText();
-    },
-    flush,
-    async finish(): Promise<void> {
-      await flush();
-      if (!sentResponse) {
-        await send("(no response)");
-      }
-    },
-  };
 }
 
 function splitHead(text: string, limit: number): { head: string; tail: string } {

--- a/src/lib/reply.ts
+++ b/src/lib/reply.ts
@@ -4,19 +4,9 @@ export interface ReplyContext {
   reply: (text: string) => Promise<unknown>;
 }
 
-export interface Reply {
-  send: (text: string) => Promise<void>;
-  system: (text: string) => Promise<void>;
-  stream: () => ResponseWriter;
-}
+export type Reply = ReturnType<typeof createReply>;
 
-interface ResponseWriter {
-  write: (text: string) => Promise<void>;
-  flush: () => Promise<void>;
-  finish: () => Promise<void>;
-}
-
-export function createReply(options: { context: ReplyContext; limit: number }): Reply {
+export function createReply(options: { context: ReplyContext; limit: number }) {
   async function send(text: string): Promise<void> {
     const parts = splitMessageText(text, options.limit);
     for (const part of parts) {
@@ -71,10 +61,7 @@ function findSplitIndex(text: string, limit: number): number {
   return limit;
 }
 
-function createResponseWriter(options: {
-  limit: number;
-  send: (text: string) => Promise<void>;
-}): ResponseWriter {
+function createResponseWriter(options: { limit: number; send: (text: string) => Promise<void> }) {
   let bufferedText = "";
   let sentResponse = false;
 

--- a/src/lib/reply.ts
+++ b/src/lib/reply.ts
@@ -19,15 +19,6 @@ export function createReply(options: { context: ReplyContext; limit: number }) {
     sent = true;
   }
 
-  async function flush(): Promise<void> {
-    if (!buffer.trim()) {
-      buffer = "";
-      return;
-    }
-    await send(buffer);
-    buffer = "";
-  }
-
   async function write(text: string): Promise<void> {
     buffer += text;
     while (buffer.length > options.limit) {
@@ -40,23 +31,27 @@ export function createReply(options: { context: ReplyContext; limit: number }) {
     }
   }
 
-  async function finish() {
-    await flush();
-    if (!sent) {
-      await send("(no response)");
+  async function flush(): Promise<void> {
+    if (!buffer.trim()) {
+      buffer = "";
+      return;
     }
+    await send(buffer);
+    buffer = "";
   }
 
   return {
     send,
-    system(text: string) {
-      return send(`[⚙️ System]\n${text}`);
-    },
     write,
     flush,
-    finish,
-    stream() {
-      return this;
+    system: (text: string) => {
+      return send(`[⚙️ System]\n${text}`);
+    },
+    finish: async () => {
+      await flush();
+      if (!sent) {
+        await send("(no response)");
+      }
     },
   };
 }

--- a/src/lib/reply.ts
+++ b/src/lib/reply.ts
@@ -49,22 +49,20 @@ function splitMessageText(text: string, limit: number): string[] {
 function findSplitIndex(text: string, limit: number): number {
   // Split at the best available natural boundary before the limit:
   // paragraph break first, then line break, then word space. If none are
-  // found, hard-split at the limit. The boundary must be in the latter half
-  // of the chunk so we do not send tiny leading fragments just to preserve a
-  // very early separator.
-  // TODO: should divions heuristics adjusted based on splitter?
-  // e.g. paragraph split can be more chunkier.
-  const paragraphIndex = text.lastIndexOf("\n\n", limit);
-  if (paragraphIndex > limit / 2) {
-    return paragraphIndex + 2;
-  }
-  const lineIndex = text.lastIndexOf("\n", limit);
-  if (lineIndex > limit / 2) {
-    return lineIndex + 1;
-  }
-  const spaceIndex = text.lastIndexOf(" ", limit);
-  if (spaceIndex > limit / 2) {
-    return spaceIndex + 1;
+  // found, hard-split at the limit. Paragraphs can produce slightly smaller
+  // chunks because they are stronger boundaries; weaker boundaries must be in
+  // the latter half so we do not send tiny leading fragments just to preserve
+  // a very early separator.
+  const splitters = [
+    { value: "\n\n", minRatio: 0.3 },
+    { value: "\n", minRatio: 0.5 },
+    { value: " ", minRatio: 0.5 },
+  ];
+  for (const splitter of splitters) {
+    const index = text.lastIndexOf(splitter.value, limit);
+    if (index > limit * splitter.minRatio) {
+      return index + splitter.value.length;
+    }
   }
   return limit;
 }

--- a/src/lib/reply.ts
+++ b/src/lib/reply.ts
@@ -1,3 +1,4 @@
+// TODO: link to reference
 export const MESSAGE_SPLIT_BUDGET = 3900;
 
 export interface ReplyContext {


### PR DESCRIPTION
## Summary

- add a single reply helper with `send` and `stream` methods
- route system messages through `send(..., { system: true })`
- keep direct Telegram `context.reply` usage isolated inside the helper

## Verification

- `pnpm lint`