### PR TITLE
feat: toggle tool-call output verbosity

### DIFF
--- a/docs/tasks/2026-04-14-toggle-tool-call-verbose.md
+++ b/docs/tasks/2026-04-14-toggle-tool-call-verbose.md
@@ -1,0 +1,101 @@
+# Toggle Tool Call Verbosity
+
+## Problem Context And Approach
+
+Backlog item: `feat: toggle tool call in response`.
+
+acpella currently emits ACP `tool_call` updates into the user-facing reply as `Tool: <title>` from `src/handler.ts`. That is useful for visibility, but users need a session-scoped toggle so they can hide tool-call noise without changing the agent or losing normal assistant text.
+
+MVP behavior:
+
+- Tool-call responses are visible by default.
+- The setting persists in `stateFile` per acpella session name.
+- Local system commands are handled by acpella and are not sent to the agent:
+  - `/verbose` reports current status and help.
+  - `/verbose on` enables tool-call responses.
+  - `/verbose off` disables tool-call responses.
+
+Implementation should keep the feature local to the messaging/router layer. ACP sessions still receive all updates; acpella only decides whether `tool_call` updates are written into the outgoing reply.
+
+## Reference Files And Patterns
+
+- `src/handler.ts` routes local commands before normal prompts. Existing command examples are `/status`, `/cancel`, `/service ...`, and `/session ...`.
+- `src/handler.ts` currently handles `tool_call` updates inside `handlePrompt` by flushing pending assistant text, writing `Tool: ${update.title}`, and flushing again.
+- `src/state.ts` owns the JSON `stateFile`. It is scoped by `config.agent.command`, then by acpella session name.
+- `src/state.ts` currently stores only `{ sessionId }` for each session. Its narrow `getSessionId()` / `setSessionId()` API should be replaced with `getSession()` / `setSession()` so session-id persistence and preferences share one entry-level API.
+- `src/handler.test.ts` covers handler-level command behavior and inline snapshots for user-visible replies.
+- `src/lib/test-agent.ts` is the built-in ACP test agent. It can be extended with a prompt trigger that emits a synthetic `tool_call` update before the echoed assistant text.
+
+## State Shape
+
+Extend the existing per-session entry rather than adding a separate top-level map:
+
+```ts
+sessions: {
+  [sessionName: string]: {
+    sessionId?: string;
+    verbose?: boolean;
+  };
+}
+```
+
+Interpret `verbose === undefined` as `true` to preserve the default-on behavior and avoid requiring a migration for existing state files.
+
+Important follow-up edits caused by optional `sessionId`:
+
+- Replace `getSessionId(sessionName)` with `getSession(sessionName)`, returning the full entry or `undefined`.
+- Replace `setSessionId(sessionName, sessionId)` with `setSession(sessionName, patch)`, merging with the existing entry instead of overwriting it.
+- Existing call sites should read `state.getSession(name)?.sessionId`.
+- Session-id writes should become `state.setSession(name, { sessionId })`, preserving `verbose`.
+- Verbose writes should become `state.setSession(name, { verbose })`, preserving `sessionId`.
+- `deleteSession(sessionName)` needs a decision:
+  - Preferred MVP: remove only `sessionId` and preserve `verbose`, because `/session close` should not unexpectedly reset display preferences.
+  - If the resulting entry has neither `sessionId` nor non-default preferences, it can be deleted to keep the file small.
+- `handleListSessions()` should ignore state entries that have no `sessionId`, otherwise preference-only entries would render as broken session mappings.
+
+Keep `version: 1` unless a stronger migration policy is added at the same time. The schema can be made backward-compatible by changing only the session entry object.
+
+## Implementation Plan
+
+1. Update `src/state.ts` schema and store API.
+   - Add optional `verbose: z.boolean().optional()` to each session entry.
+   - Make `sessionId` optional in the schema.
+   - Replace `getSessionId(sessionName)` with `getSession(sessionName)`, returning `Scope["sessions"][string] | undefined`.
+   - Replace `setSessionId(sessionName, sessionId)` with `setSession(sessionName, patch)`, merging the patch with any existing entry.
+   - Avoid adding separate `getVerbose()` / `setVerbose()` methods; derive verbose behavior from `state.getSession(name)?.verbose ?? true` and write it with `state.setSession(name, { verbose })`.
+   - Change `deleteSession()` to clear the `sessionId` while preserving a non-default `verbose: false` preference; remove the entry only when it has no useful data left.
+
+2. Gate tool-call reply output in `src/handler.ts`.
+   - Read the setting at the start of `handlePrompt`, for example `const verbose = state.getSession(options.name)?.verbose ?? true`.
+   - Keep console logging of ACP update types unchanged.
+   - For `tool_call` updates:
+     - If verbose is enabled, preserve current behavior: flush text, write `Tool: ${update.title}`, flush.
+     - If verbose is disabled, do not write anything to the user reply for that update.
+
+3. Add a local verbose command handler in `src/handler.ts`.
+   - Parse the exact system command forms from the MVP scope: `/verbose`, `/verbose on`, `/verbose off`.
+   - Route it before `handlePrompt()` so those messages are never sent to the agent.
+   - `/verbose` response should include current status plus help, e.g.
+     - `verbose: on`
+     - `Usage: /verbose [on|off]`
+   - `/verbose on` response should confirm `verbose: on`.
+   - `/verbose off` response should confirm `verbose: off`.
+   - For unknown arguments, return the same status/help response instead of forwarding to the agent.
+
+4. Extend tests.
+   - Add handler coverage that `/verbose` reports default `on`.
+   - Add handler coverage that `/verbose off` persists in `stateFile` and `/verbose` reports `off` for the same acpella session.
+   - Add handler coverage that another acpella session still defaults to `on`.
+   - Add regression coverage that saving/loading an ACP `sessionId` does not erase `verbose: false`.
+   - Add regression coverage for the new `getSession()` / `setSession()` merge behavior.
+   - Extend `src/lib/test-agent.ts` with a deterministic prompt trigger such as `__tool:<title>` that emits a `tool_call` update plus normal assistant text.
+   - Test that tool-call text is included by default and after `/verbose on`.
+   - Test that tool-call text is omitted after `/verbose off` while normal assistant text is still returned.
+
+## Out Of Scope For MVP
+
+- Hiding other ACP update types besides `tool_call`.
+- Per-agent or global default configuration.
+- Formatting richer tool-call details beyond the existing title.
+- Changing ACP agent behavior or tool execution.
+- Telegram bot command registration for `/verbose`.

--- a/src/handler.test.ts
+++ b/src/handler.test.ts
@@ -69,4 +69,40 @@ describe(createHandler, () => {
       - (unknown) -> other-session (active)"
     `);
   });
+
+  test("verbose command toggles tool call output", async () => {
+    const tester = await createHandlerTester();
+    const session = tester.createSession("test");
+
+    expect(await session.request("hello")).toMatchInlineSnapshot(`"echo: hello"`);
+    expect(await session.request("/verbose")).toMatchInlineSnapshot(`
+      "[⚙️ System]
+      Tool call output: on
+      Usage: /verbose [on|off]"
+    `);
+    expect(await session.request("__tool:Read files")).toMatchInlineSnapshot(`
+      "Tool: Read files
+      echo: __tool:Read files"
+    `);
+    expect(await session.request("/verbose off")).toMatchInlineSnapshot(`
+      "[⚙️ System]
+      Tool call output: off"
+    `);
+    expect(await session.request("__tool:Search docs")).toMatchInlineSnapshot(
+      `"echo: __tool:Search docs"`,
+    );
+    expect(await session.request("/verbose")).toMatchInlineSnapshot(`
+      "[⚙️ System]
+      Tool call output: off
+      Usage: /verbose [on|off]"
+    `);
+    expect(await session.request("/verbose on")).toMatchInlineSnapshot(`
+      "[⚙️ System]
+      Tool call output: on"
+    `);
+    expect(await session.request("__tool:Edit file")).toMatchInlineSnapshot(`
+      "Tool: Edit file
+      echo: __tool:Edit file"
+    `);
+  });
 });

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -5,6 +5,7 @@ import type { AppConfig } from "./config.ts";
 import { createReply, MESSAGE_SPLIT_BUDGET } from "./lib/reply.ts";
 import type { Reply, ReplyContext } from "./lib/reply.ts";
 import { createSessionStateStore } from "./state.ts";
+import type { StateSession } from "./state.ts";
 
 interface Handler {
   handle: (options: { session: string; context: HandlerContext }) => Promise<void>;
@@ -32,25 +33,25 @@ export async function createHandler(
     reply: Reply;
     name: string;
     text: string;
-    sessionId?: string;
+    stateSession?: StateSession;
   }): Promise<void> {
-    const { reply } = options;
+    const { reply, stateSession } = options;
     if (activeSessions.has(options.name)) {
       await reply.system("Agent turn already in progress. Send /cancel to stop it.");
       return;
     }
 
-    const session = options.sessionId
+    const verbose = stateSession?.verbose ?? true;
+    const sessionId = stateSession?.sessionId;
+    const session = sessionId
       ? await manager.loadSession({
           sessionCwd: config.home,
-          sessionId: options.sessionId,
+          sessionId,
         })
       : await manager.newSession({ sessionCwd: config.home });
 
     try {
-      const customPrompt = !options.sessionId
-        ? readOptionalPromptFile(config.prompt.file)
-        : undefined;
+      const customPrompt = !sessionId ? readOptionalPromptFile(config.prompt.file) : undefined;
       const promptText = customPrompt
         ? formatFirstPrompt({ customPrompt, userText: options.text })
         : options.text;
@@ -63,9 +64,11 @@ export async function createHandler(
           await reply.write(update.content.text);
         } else if (update.sessionUpdate === "tool_call") {
           console.log(`[acp:update] tool_call: ${update.title}`);
-          await reply.flush();
-          await reply.write(`Tool: ${update.title}`);
-          await reply.flush();
+          if (verbose) {
+            await reply.flush();
+            await reply.write(`Tool: ${update.title}`);
+            await reply.flush();
+          }
         } else {
           console.log(`[acp:update] ${update.sessionUpdate}`);
         }
@@ -76,8 +79,8 @@ export async function createHandler(
         return;
       }
       await reply.finish();
-      if (!options.sessionId) {
-        state.setSessionId(options.name, session.sessionId);
+      if (!sessionId) {
+        state.setSession(options.name, { sessionId: session.sessionId });
       }
     } finally {
       if (activeSessions.get(options.name) === session) {
@@ -110,7 +113,7 @@ export async function createHandler(
     name: string;
     sessionIdArg?: string;
   }): Promise<void> {
-    const currentSessionId = state.getSessionId(options.name);
+    const currentSessionId = state.getSession(options.name)?.sessionId;
     const sessionId = options.sessionIdArg ?? currentSessionId;
     if (sessionId) {
       try {
@@ -145,7 +148,7 @@ export async function createHandler(
       sessionId: options.sessionId,
     });
     try {
-      state.setSessionId(options.name, session.sessionId);
+      state.setSession(options.name, { sessionId: session.sessionId });
       return `Loaded session: ${session.sessionId}`;
     } finally {
       session.close();
@@ -156,7 +159,7 @@ export async function createHandler(
     return `\
 session: ${options.name}
 agent: ${config.agent.alias}
-session id: ${state.getSessionId(options.name) ?? "none"}`;
+session id: ${state.getSession(options.name)?.sessionId ?? "none"}`;
   }
 
   async function handleListSessions(): Promise<string> {
@@ -297,7 +300,7 @@ home: ${config.home}
       reply,
       name: sessionName,
       text,
-      sessionId: state.getSessionId(sessionName),
+      stateSession: state.getSession(sessionName),
     });
   };
 

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -252,6 +252,54 @@ Usage:
     return true;
   }
 
+  async function handleVerboseCommand(options: {
+    reply: Reply;
+    text: string;
+    sessionName: string;
+    stateSession?: StateSession;
+  }): Promise<boolean> {
+    const [command, subcommand] = options.text.trim().split(/\s+/);
+    if (command !== "/verbose") {
+      return false;
+    }
+
+    const verbose = options.stateSession?.verbose ?? true;
+    const verboseStatus = `Tool call output: ${verbose ? "on" : "off"}`;
+    const verboseHelp = `\
+${verboseStatus}
+Usage: /verbose [on|off]
+`;
+
+    let response: string;
+    switch (subcommand) {
+      case undefined: {
+        response = verboseHelp;
+        break;
+      }
+      case "on":
+      case "off": {
+        if (!options.stateSession) {
+          response = `\
+No session. Send a prompt first, then use /verbose ${subcommand}.
+
+${verboseHelp}`;
+          break;
+        }
+        state.setSession(options.sessionName, {
+          ...options.stateSession,
+          verbose: subcommand === "on",
+        });
+        response = `Tool call output: ${subcommand}`;
+        break;
+      }
+      default: {
+        response = verboseHelp;
+      }
+    }
+    await options.reply.system(response);
+    return true;
+  }
+
   function handleStatus(): string {
     return `\
 status: running
@@ -264,6 +312,7 @@ home: ${config.home}
   const handle: Handler["handle"] = async (options) => {
     const text = options.context.message!.text!;
     const sessionName = options.session;
+    const stateSession = state.getSession(sessionName);
     const reply = createReply({
       context: options.context,
       limit: MESSAGE_SPLIT_BUDGET,
@@ -287,6 +336,15 @@ home: ${config.home}
     if (handledServiceCommand) {
       return;
     }
+    const handledVerboseCommand = await handleVerboseCommand({
+      reply,
+      text,
+      sessionName,
+      stateSession,
+    });
+    if (handledVerboseCommand) {
+      return;
+    }
     const handledSessionCommand = await handleSessionCommand({
       reply,
       text,
@@ -300,7 +358,7 @@ home: ${config.home}
       reply,
       name: sessionName,
       text,
-      stateSession: state.getSession(sessionName),
+      stateSession,
     });
   };
 

--- a/src/lib/test-agent.ts
+++ b/src/lib/test-agent.ts
@@ -90,6 +90,17 @@ class EchoAgent implements Agent {
       const key = text.slice(6);
       const value = process.env[key] ?? "(unset)";
       reportText = `env: ${key}=${value}`;
+    } else if (text.startsWith("__tool:")) {
+      const title = text.slice(7);
+      await this.connection.sessionUpdate({
+        sessionId: params.sessionId,
+        update: {
+          sessionUpdate: "tool_call",
+          toolCallId: "__testToolCall",
+          title,
+        },
+      });
+      reportText = `echo: ${text}`;
     } else {
       reportText = `echo: ${text}`;
     }

--- a/src/state.ts
+++ b/src/state.ts
@@ -22,6 +22,7 @@ const stateSchema = z
           z.string().min(1), // sessionName
           z.object({
             sessionId: z.string().min(1),
+            verbose: z.boolean().optional(),
           }),
         ),
       }),
@@ -31,7 +32,7 @@ const stateSchema = z
 
 type State = z.infer<typeof stateSchema>;
 type Scope = State["scopes"][string];
-
+export type StateSession = Scope["sessions"][string];
 export type SessionStateStore = ReturnType<typeof createSessionStateStore>;
 
 export function createSessionStateStore(config: Pick<AppConfig, "agent" | "stateFile">) {
@@ -72,12 +73,12 @@ export function createSessionStateStore(config: Pick<AppConfig, "agent" | "state
 
   return {
     getSessions,
-    getSessionId(sessionName: string) {
-      return getSessions()[sessionName]?.sessionId;
+    getSession(sessionName: string) {
+      return getSessions()[sessionName];
     },
-    setSessionId(sessionName: string, sessionId: string) {
+    setSession(sessionName: string, patch: StateSession) {
       const sessions = getSessions();
-      sessions[sessionName] = { sessionId };
+      sessions[sessionName] = { ...sessions[sessionName], ...patch };
       writeSessions(sessions);
     },
     deleteSession(sessionName: string) {


### PR DESCRIPTION
## Summary

- add session-state support for a `verbose` preference while preserving the required ACP `sessionId`
- gate user-facing `tool_call` output based on that preference, defaulting to on
- add `/verbose`, `/verbose on`, and `/verbose off` system commands
- cover the full handler flow with a deterministic test-agent tool-call trigger

## Verification

- `pnpm exec tsc --noEmit`
- `pnpm test -- src/handler.test.ts`