### PR TITLE
feat: expand custom skills directive

### DIFF
--- a/fixtures/prompt-directives/AGENTS.md
+++ b/fixtures/prompt-directives/AGENTS.md
@@ -1,0 +1,6 @@
+before
+::acpella skills ./skills
+::acpella future ./thing
+inline ::acpella skills ./skills stays literal
+::acpella skills ./missing
+after

--- a/fixtures/prompt-directives/skills/alpha/SKILL.md
+++ b/fixtures/prompt-directives/skills/alpha/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: alpha
-description: Alpha skill description.
+description: >-
+  Alpha skill description.
 ---
 
 Alpha body should not be included.

--- a/fixtures/prompt-directives/skills/alpha/SKILL.md
+++ b/fixtures/prompt-directives/skills/alpha/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: alpha
+description: Alpha skill description.
+---
+
+Alpha body should not be included.

--- a/fixtures/prompt-directives/skills/beta/SKILL.md
+++ b/fixtures/prompt-directives/skills/beta/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: beta
+description: "Beta skill description."
+---
+
+Beta body should not be included.

--- a/fixtures/prompt-directives/skills/no-description/SKILL.md
+++ b/fixtures/prompt-directives/skills/no-description/SKILL.md
@@ -1,0 +1,5 @@
+---
+name: no-description
+---
+
+Missing description should skip this skill.

--- a/src/lib/prompt.test.ts
+++ b/src/lib/prompt.test.ts
@@ -45,10 +45,6 @@ test("acpella skills directive", () => {
 
     <custom_instructions>
     before
-    ### Available Skills
-
-    When a task matches one of these skills, read the listed SKILL.md before acting.
-
     - Skill directory: alpha
       File: <root>/fixtures/prompt-directives/skills/alpha/SKILL.md
       Frontmatter:

--- a/src/lib/prompt.test.ts
+++ b/src/lib/prompt.test.ts
@@ -49,13 +49,29 @@ test("acpella skills directive", () => {
 
     When a task matches one of these skills, read the listed SKILL.md before acting.
 
-    - alpha
-      Description: Alpha skill description.
+    - Skill directory: alpha
       File: <root>/fixtures/prompt-directives/skills/alpha/SKILL.md
+      Frontmatter:
+        ---
+        name: alpha
+        description: >-
+          Alpha skill description.
+        ---
 
-    - beta
-      Description: Beta skill description.
+    - Skill directory: beta
       File: <root>/fixtures/prompt-directives/skills/beta/SKILL.md
+      Frontmatter:
+        ---
+        name: beta
+        description: "Beta skill description."
+        ---
+
+    - Skill directory: no-description
+      File: <root>/fixtures/prompt-directives/skills/no-description/SKILL.md
+      Frontmatter:
+        ---
+        name: no-description
+        ---
 
     ::acpella future ./thing
     inline ::acpella skills ./skills stays literal

--- a/src/lib/prompt.test.ts
+++ b/src/lib/prompt.test.ts
@@ -33,3 +33,36 @@ test("not-found", () => {
   });
   expect(output).toMatchInlineSnapshot(`"my first message"`);
 });
+
+test("acpella skills directive", () => {
+  const root = process.cwd();
+  const output = buildFirstPrompt({
+    promptFile: path.resolve("./fixtures/prompt-directives/AGENTS.md"),
+    text: "my first message",
+  });
+  expect(output.replaceAll(root, "<root>")).toMatchInlineSnapshot(`
+    "Use these additional instructions for this session:
+
+    <custom_instructions>
+    before
+    ### Available Skills
+
+    When a task matches one of these skills, read the listed SKILL.md before acting.
+
+    - alpha
+      Description: Alpha skill description.
+      File: <root>/fixtures/prompt-directives/skills/alpha/SKILL.md
+
+    - beta
+      Description: Beta skill description.
+      File: <root>/fixtures/prompt-directives/skills/beta/SKILL.md
+
+    ::acpella future ./thing
+    inline ::acpella skills ./skills stays literal
+    ::acpella skills ./missing
+    after
+    </custom_instructions>
+
+    my first message"
+  `);
+});

--- a/src/lib/prompt.ts
+++ b/src/lib/prompt.ts
@@ -68,9 +68,7 @@ function expandAcpellaDirective(options: {
     return options.line;
   }
 
-  const skillsDir = path.isAbsolute(options.args)
-    ? options.args
-    : path.resolve(path.dirname(options.file), options.args);
+  const skillsDir = path.resolve(path.dirname(options.file), options.args);
   try {
     return buildSkillsCatalog(skillsDir);
   } catch {

--- a/src/lib/prompt.ts
+++ b/src/lib/prompt.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 const INCLUDE_LINE_RE = /^[^\S\r\n]*@(\S+)[^\S\r\n]*$/gm;
+const ACP_DIRECTIVE_LINE_RE = /^[^\S\r\n]*::acpella\s+(\S+)(?:\s+(.+?))?[^\S\r\n]*$/gm;
 
 export function buildFirstPrompt(options: { promptFile: string; text: string }): string {
   let output = "";
@@ -39,7 +40,7 @@ function readPromptFileWithIncludes(file: string, seen: Set<string>): string {
   seen.add(file);
   try {
     const text = fs.readFileSync(file, "utf8");
-    return text.replace(INCLUDE_LINE_RE, (line, includePath: string) => {
+    const included = text.replace(INCLUDE_LINE_RE, (line, includePath: string) => {
       const target = path.isAbsolute(includePath)
         ? includePath
         : path.resolve(path.dirname(file), includePath);
@@ -49,9 +50,101 @@ function readPromptFileWithIncludes(file: string, seen: Set<string>): string {
         return line;
       }
     });
+    return included.replace(ACP_DIRECTIVE_LINE_RE, (line, command: string, args?: string) => {
+      return expandAcpellaDirective({ line, command, args, file });
+    });
   } finally {
     seen.delete(file);
   }
+}
+
+function expandAcpellaDirective(options: {
+  line: string;
+  command: string;
+  args: string | undefined;
+  file: string;
+}): string {
+  if (options.command !== "skills" || !options.args) {
+    return options.line;
+  }
+
+  const skillsDir = path.isAbsolute(options.args)
+    ? options.args
+    : path.resolve(path.dirname(options.file), options.args);
+  try {
+    return buildSkillsCatalog(skillsDir);
+  } catch {
+    return options.line;
+  }
+}
+
+function buildSkillsCatalog(skillsDir: string): string {
+  const skills = fs
+    .readdirSync(skillsDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .flatMap((entry) => readSkillMetadata(path.join(skillsDir, entry.name, "SKILL.md")));
+
+  skills.sort((a, b) => a.name.localeCompare(b.name));
+
+  let output = `\
+### Available Skills
+
+When a task matches one of these skills, read the listed SKILL.md before acting.`;
+  for (const skill of skills) {
+    output += `
+
+- ${skill.name}
+  Description: ${skill.description}
+  File: ${skill.file}`;
+  }
+  return `${output}\n`;
+}
+
+function readSkillMetadata(file: string): { name: string; description: string; file: string }[] {
+  let text: string;
+  try {
+    text = fs.readFileSync(file, "utf8");
+  } catch {
+    return [];
+  }
+
+  const frontmatter = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/.exec(text);
+  if (!frontmatter) {
+    return [];
+  }
+  const metadata = parseFrontmatter(frontmatter[1]);
+  if (!metadata.name || !metadata.description) {
+    return [];
+  }
+  return [{ name: metadata.name, description: metadata.description, file }];
+}
+
+function parseFrontmatter(text: string): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const line of text.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) {
+      continue;
+    }
+    const separator = trimmed.indexOf(":");
+    if (separator === -1) {
+      continue;
+    }
+    const key = trimmed.slice(0, separator).trim();
+    const value = trimmed.slice(separator + 1).trim();
+    result[key] = unquoteYamlScalar(value);
+  }
+  return result;
+}
+
+function unquoteYamlScalar(value: string): string {
+  if (
+    (value.startsWith('"') && value.endsWith('"')) ||
+    (value.startsWith("'") && value.endsWith("'"))
+  ) {
+    return value.slice(1, -1);
+  }
+  return value;
 }
 
 function isNodeError(error: unknown): error is NodeJS.ErrnoException {

--- a/src/lib/prompt.ts
+++ b/src/lib/prompt.ts
@@ -82,11 +82,16 @@ function buildSkillsCatalog(skillsDir: string): string {
   const skills = fs
     .readdirSync(skillsDir, { withFileTypes: true })
     .filter((entry) => entry.isDirectory())
-    .flatMap((entry) => readSkillMetadata(path.join(skillsDir, entry.name, "SKILL.md")));
+    .flatMap((entry) =>
+      readSkillCatalogEntry({
+        directory: entry.name,
+        file: path.join(skillsDir, entry.name, "SKILL.md"),
+      }),
+    );
 
-  skills.sort((a, b) => a.name.localeCompare(b.name));
+  skills.sort((a, b) => a.directory.localeCompare(b.directory));
 
-  // Keep this catalog close to Codex's skill listing: name, description, and file path only.
+  // Keep this catalog close to Codex's skill listing: metadata and file path only.
   let output = `\
 ### Available Skills
 
@@ -94,58 +99,47 @@ When a task matches one of these skills, read the listed SKILL.md before acting.
   for (const skill of skills) {
     output += `
 
-- ${skill.name}
-  Description: ${skill.description}
-  File: ${skill.file}`;
+- Skill directory: ${skill.directory}
+  File: ${skill.file}
+  Frontmatter:
+${indentBlock(skill.frontmatter ?? "(none)", "    ")}`;
   }
   return `${output}\n`;
 }
 
-function readSkillMetadata(file: string): { name: string; description: string; file: string }[] {
+function readSkillCatalogEntry(options: {
+  directory: string;
+  file: string;
+}): { directory: string; file: string; frontmatter?: string }[] {
   let text: string;
   try {
-    text = fs.readFileSync(file, "utf8");
+    text = fs.readFileSync(options.file, "utf8");
   } catch {
     return [];
   }
 
-  const frontmatter = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/.exec(text);
-  if (!frontmatter) {
-    return [];
-  }
-  const metadata = parseFrontmatter(frontmatter[1]);
-  if (!metadata.name || !metadata.description) {
-    return [];
-  }
-  return [{ name: metadata.name, description: metadata.description, file }];
+  return [
+    {
+      directory: options.directory,
+      file: options.file,
+      frontmatter: readFrontmatter(text),
+    },
+  ];
 }
 
-function parseFrontmatter(text: string): Record<string, string> {
-  const result: Record<string, string> = {};
-  for (const line of text.split(/\r?\n/)) {
-    const trimmed = line.trim();
-    if (!trimmed || trimmed.startsWith("#")) {
-      continue;
-    }
-    const separator = trimmed.indexOf(":");
-    if (separator === -1) {
-      continue;
-    }
-    const key = trimmed.slice(0, separator).trim();
-    const value = trimmed.slice(separator + 1).trim();
-    result[key] = unquoteYamlScalar(value);
+function readFrontmatter(text: string): string | undefined {
+  const match = /^---(?:\r?\n[\s\S]*?\r?\n)---(?=\r?\n|$)/.exec(text);
+  if (!match) {
+    return;
   }
-  return result;
+  return match[0];
 }
 
-function unquoteYamlScalar(value: string): string {
-  if (
-    (value.startsWith('"') && value.endsWith('"')) ||
-    (value.startsWith("'") && value.endsWith("'"))
-  ) {
-    return value.slice(1, -1);
-  }
-  return value;
+function indentBlock(text: string, indent: string): string {
+  return text
+    .split(/\r?\n/)
+    .map((line) => `${indent}${line}`)
+    .join("\n");
 }
 
 function isNodeError(error: unknown): error is NodeJS.ErrnoException {

--- a/src/lib/prompt.ts
+++ b/src/lib/prompt.ts
@@ -86,6 +86,7 @@ function buildSkillsCatalog(skillsDir: string): string {
 
   skills.sort((a, b) => a.name.localeCompare(b.name));
 
+  // Keep this catalog close to Codex's skill listing: name, description, and file path only.
   let output = `\
 ### Available Skills
 

--- a/src/lib/prompt.ts
+++ b/src/lib/prompt.ts
@@ -39,8 +39,8 @@ function readPromptFileWithIncludes(file: string, seen: Set<string>): string {
 
   seen.add(file);
   try {
-    const text = fs.readFileSync(file, "utf8");
-    const included = text.replace(INCLUDE_LINE_RE, (line, includePath: string) => {
+    let text = fs.readFileSync(file, "utf8");
+    text = text.replace(INCLUDE_LINE_RE, (line, includePath: string) => {
       const target = path.isAbsolute(includePath)
         ? includePath
         : path.resolve(path.dirname(file), includePath);
@@ -50,13 +50,14 @@ function readPromptFileWithIncludes(file: string, seen: Set<string>): string {
         return line;
       }
     });
-    return included.replace(ACP_DIRECTIVE_LINE_RE, (line, command: string, args?: string) => {
+    text = text.replace(ACP_DIRECTIVE_LINE_RE, (line, command: string, args?: string) => {
       try {
         return expandAcpellaDirective({ line, command, args, file });
       } catch {
         return line;
       }
     });
+    return text;
   } finally {
     seen.delete(file);
   }

--- a/src/lib/prompt.ts
+++ b/src/lib/prompt.ts
@@ -51,7 +51,11 @@ function readPromptFileWithIncludes(file: string, seen: Set<string>): string {
       }
     });
     return included.replace(ACP_DIRECTIVE_LINE_RE, (line, command: string, args?: string) => {
-      return expandAcpellaDirective({ line, command, args, file });
+      try {
+        return expandAcpellaDirective({ line, command, args, file });
+      } catch {
+        return line;
+      }
     });
   } finally {
     seen.delete(file);
@@ -69,11 +73,7 @@ function expandAcpellaDirective(options: {
   }
 
   const skillsDir = path.resolve(path.dirname(options.file), options.args);
-  try {
-    return buildSkillsCatalog(skillsDir);
-  } catch {
-    return options.line;
-  }
+  return buildSkillsCatalog(skillsDir);
 }
 
 function buildSkillsCatalog(skillsDir: string): string {

--- a/src/lib/prompt.ts
+++ b/src/lib/prompt.ts
@@ -77,58 +77,41 @@ function expandAcpellaDirective(options: {
 }
 
 function buildSkillsCatalog(skillsDir: string): string {
-  const skills = fs
-    .readdirSync(skillsDir, { withFileTypes: true })
-    .filter((entry) => entry.isDirectory())
-    .flatMap((entry) =>
-      readSkillCatalogEntry({
-        directory: entry.name,
-        file: path.join(skillsDir, entry.name, "SKILL.md"),
-      }),
-    );
+  const skillsDirStat = fs.statSync(skillsDir);
+  if (!skillsDirStat.isDirectory()) {
+    throw new Error(`Skills path is not a directory: ${skillsDir}`);
+  }
 
-  skills.sort((a, b) => a.directory.localeCompare(b.directory));
+  const files = fs.globSync("*/SKILL.md", { cwd: skillsDir });
+  files.sort();
 
   // Keep this catalog close to Codex's skill listing: metadata and file path only.
   let output = "";
-  for (const skill of skills) {
-    output += `${output ? "\n\n" : ""}- Skill directory: ${skill.directory}
-  File: ${skill.file}
+  for (const file of files) {
+    const filePath = path.resolve(skillsDir, file);
+    let content: string;
+    try {
+      content = fs.readFileSync(filePath, "utf8");
+    } catch {
+      continue;
+    }
+    output += `
+- Skill directory: ${path.basename(path.dirname(filePath))}
+  File: ${filePath}
   Frontmatter:
-${indentBlock(skill.frontmatter ?? "(none)", "    ")}`;
+${addIndent(readFrontmatter(content) ?? "(none)", "    ")}
+`;
   }
-  return output ? `${output}\n` : "";
+  return output.trim() + "\n";
 }
 
-function readSkillCatalogEntry(options: {
-  directory: string;
-  file: string;
-}): { directory: string; file: string; frontmatter?: string }[] {
-  let text: string;
-  try {
-    text = fs.readFileSync(options.file, "utf8");
-  } catch {
-    return [];
-  }
+const FRONTMATTER_RE = /^---(?:\r?\n[\s\S]*?\r?\n)---(?=\r?\n|$)/;
 
-  return [
-    {
-      directory: options.directory,
-      file: options.file,
-      frontmatter: readFrontmatter(text),
-    },
-  ];
+function readFrontmatter(content: string) {
+  return content.match(FRONTMATTER_RE)?.[0];
 }
 
-function readFrontmatter(text: string): string | undefined {
-  const match = /^---(?:\r?\n[\s\S]*?\r?\n)---(?=\r?\n|$)/.exec(text);
-  if (!match) {
-    return;
-  }
-  return match[0];
-}
-
-function indentBlock(text: string, indent: string): string {
+function addIndent(text: string, indent: string): string {
   return text
     .split(/\r?\n/)
     .map((line) => `${indent}${line}`)

--- a/src/lib/prompt.ts
+++ b/src/lib/prompt.ts
@@ -92,19 +92,14 @@ function buildSkillsCatalog(skillsDir: string): string {
   skills.sort((a, b) => a.directory.localeCompare(b.directory));
 
   // Keep this catalog close to Codex's skill listing: metadata and file path only.
-  let output = `\
-### Available Skills
-
-When a task matches one of these skills, read the listed SKILL.md before acting.`;
+  let output = "";
   for (const skill of skills) {
-    output += `
-
-- Skill directory: ${skill.directory}
+    output += `${output ? "\n\n" : ""}- Skill directory: ${skill.directory}
   File: ${skill.file}
   Frontmatter:
 ${indentBlock(skill.frontmatter ?? "(none)", "    ")}`;
   }
-  return `${output}\n`;
+  return output ? `${output}\n` : "";
 }
 
 function readSkillCatalogEntry(options: {


### PR DESCRIPTION
## Summary

- expand whole-line ::acpella skills <dir> directives while loading prompt files
- generate a lightweight available-skills catalog from immediate */SKILL.md files
- preserve unknown directives and failed skill discovery lines literally
- add fixtures covering expansion, unknown directives, inline literals, and missing directories

Closes #56

## Follow-up TODO

After this lands, update Clawd home's .acpella/AGENTS.md to add an explicit local skills section, for example:

```md
## Available Clawd Skills

The following local skills are discoverable workflow documentation. When the current task matches a skill's frontmatter, read that skill's SKILL.md before acting. Do not bulk-load unrelated skills.

Some skills may mention OpenClaw-only tools or surfaces. Treat those parts as workflow context unless acpella actually provides the same capability.

::acpella skills ../skills
```

## Verification

- pnpm vitest --project=unit src/lib/prompt.test.ts
- pnpm lint
- pnpm test