### PR TITLE
fix: retry on Telegram 429 error replies

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,8 +1,9 @@
 import path from "node:path";
 import { createInterface } from "node:readline/promises";
+import { setTimeout as sleep } from "node:timers/promises";
 import { parseArgs } from "node:util";
 import { run, sequentialize } from "@grammyjs/runner";
-import { Bot, Context } from "grammy";
+import { Bot, GrammyError, type Context } from "grammy";
 import { loadConfig, type AppConfig } from "./config.ts";
 import { createHandler, type Handler } from "./handler.ts";
 import { handleSetupSystemd } from "./lib/systemd.ts";
@@ -88,8 +89,20 @@ Options:
     }));
     await bot.api.setMyCommands(commands);
   } catch (error) {
-    console.error("[telegram] failed to register bot commands:", error);
+    console.error("[telegram] failed to register bot commands:", summarizeError(error));
   }
+
+  bot.catch((error) => {
+    const ctx = error.ctx;
+    const sessionName = telegramSessionName(ctx);
+    const label = `[${sessionName}:${ctx.message?.message_id ?? "unknown"}]`;
+    console.error(`${label} (bot error)`, {
+      updateId: ctx.update.update_id,
+      chatId: ctx.chat?.id,
+      threadId: ctx.message?.message_thread_id,
+      error: summarizeError(error.error),
+    });
+  });
 
   // handle messages from each session and system commands concurrently
   bot.use(
@@ -140,16 +153,29 @@ Options:
               parse_mode: "HTML",
             });
           } catch (error) {
-            console.error(`${label} formatted reply failed; falling back to raw text:`, error);
+            if (getTelegramRetryAfter(error) !== undefined) {
+              throw error;
+            }
+            console.error(
+              `${label} formatted reply failed; falling back to raw text:`,
+              summarizeError(error),
+            );
             return await ctx.reply(replyText);
           }
         },
       });
       console.log(`${label} (response ok)`);
     } catch (error) {
-      console.error(`${label} (response error)`, error);
+      console.error(`${label} (response error)`, summarizeError(error));
       const message = error instanceof Error ? error.message : String(error);
-      await ctx.reply(`Error: ${truncateString(message, 200)}`);
+      try {
+        await retryTelegram429Once({
+          label,
+          action: () => ctx.reply(`Error: ${truncateString(message, 200)}`),
+        });
+      } catch (replyError) {
+        console.error(`${label} error reply failed; giving up:`, summarizeError(replyError));
+      }
     }
   });
 
@@ -168,6 +194,55 @@ function telegramSessionName(context: Context): string {
   return ["tg", context.chat?.id ?? "unknown", context.message?.message_thread_id]
     .filter(Boolean)
     .join("-");
+}
+
+function getTelegramRetryAfter(error: unknown): number | undefined {
+  if (!(error instanceof GrammyError) || error.error_code !== 429) {
+    return;
+  }
+  return error.parameters.retry_after;
+}
+
+async function retryTelegram429Once<T>(options: {
+  label: string;
+  action: () => Promise<T>;
+}): Promise<T> {
+  try {
+    return await options.action();
+  } catch (error) {
+    const retryAfter = getTelegramRetryAfter(error);
+    if (retryAfter === undefined) {
+      throw error;
+    }
+
+    const delaySeconds = retryAfter + 1;
+    console.warn(
+      `${options.label} telegram flood control; retrying in ${delaySeconds}s:`,
+      summarizeError(error),
+    );
+    await sleep(delaySeconds * 1000);
+    return await options.action();
+  }
+}
+
+function summarizeError(error: unknown): unknown {
+  if (error instanceof GrammyError) {
+    return {
+      name: error.name,
+      message: error.message,
+      method: error.method,
+      errorCode: error.error_code,
+      description: error.description,
+      retryAfter: error.parameters.retry_after,
+    };
+  }
+  if (error instanceof Error) {
+    return {
+      name: error.name,
+      message: error.message,
+    };
+  }
+  return String(error);
 }
 
 async function startRepl(config: AppConfig, handler: Handler, version: string) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -141,7 +141,11 @@ Options:
         if (retryAfter === undefined) {
           throw error;
         }
-        console.error(`${label} reply failed. retrying after ${retryAfter}s`, error);
+        console.error(`${label} reply failed. retrying...`, {
+          args,
+          error,
+          retryAfter,
+        });
         await sleep((retryAfter + 1) * 1000);
         return await ctx.reply(...args);
       }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -89,19 +89,14 @@ Options:
     }));
     await bot.api.setMyCommands(commands);
   } catch (error) {
-    console.error("[telegram] failed to register bot commands:", summarizeError(error));
+    console.error("[telegram] failed to register bot commands:", error);
   }
 
   bot.catch((error) => {
     const ctx = error.ctx;
     const sessionName = telegramSessionName(ctx);
     const label = `[${sessionName}:${ctx.message?.message_id ?? "unknown"}]`;
-    console.error(`${label} (bot error)`, {
-      updateId: ctx.update.update_id,
-      chatId: ctx.chat?.id,
-      threadId: ctx.message?.message_thread_id,
-      error: summarizeError(error.error),
-    });
+    console.error(`${label} (bot error)`, error.error);
   });
 
   // handle messages from each session and system commands concurrently
@@ -156,17 +151,14 @@ Options:
             if (getTelegramRetryAfter(error) !== undefined) {
               throw error;
             }
-            console.error(
-              `${label} formatted reply failed; falling back to raw text:`,
-              summarizeError(error),
-            );
+            console.error(`${label} formatted reply failed; falling back to raw text:`, error);
             return await ctx.reply(replyText);
           }
         },
       });
       console.log(`${label} (response ok)`);
     } catch (error) {
-      console.error(`${label} (response error)`, summarizeError(error));
+      console.error(`${label} (response error)`, error);
       const message = error instanceof Error ? error.message : String(error);
       try {
         await retryTelegram429Once({
@@ -174,7 +166,7 @@ Options:
           action: () => ctx.reply(`Error: ${truncateString(message, 200)}`),
         });
       } catch (replyError) {
-        console.error(`${label} error reply failed; giving up:`, summarizeError(replyError));
+        console.error(`${label} error reply failed; giving up:`, replyError);
       }
     }
   });
@@ -216,33 +208,10 @@ async function retryTelegram429Once<T>(options: {
     }
 
     const delaySeconds = retryAfter + 1;
-    console.warn(
-      `${options.label} telegram flood control; retrying in ${delaySeconds}s:`,
-      summarizeError(error),
-    );
+    console.warn(`${options.label} telegram flood control; retrying in ${delaySeconds}s:`, error);
     await sleep(delaySeconds * 1000);
     return await options.action();
   }
-}
-
-function summarizeError(error: unknown): unknown {
-  if (error instanceof GrammyError) {
-    return {
-      name: error.name,
-      message: error.message,
-      method: error.method,
-      errorCode: error.error_code,
-      description: error.description,
-      retryAfter: error.parameters.retry_after,
-    };
-  }
-  if (error instanceof Error) {
-    return {
-      name: error.name,
-      message: error.message,
-    };
-  }
-  return String(error);
 }
 
 async function startRepl(config: AppConfig, handler: Handler, version: string) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,5 @@
 import path from "node:path";
 import { createInterface } from "node:readline/promises";
-import { setTimeout as sleep } from "node:timers/promises";
 import { parseArgs } from "node:util";
 import { run, sequentialize } from "@grammyjs/runner";
 import { Bot, GrammyError, type Context } from "grammy";
@@ -8,7 +7,7 @@ import { loadConfig, type AppConfig } from "./config.ts";
 import { createHandler, type Handler } from "./handler.ts";
 import { handleSetupSystemd } from "./lib/systemd.ts";
 import { markdownToTelegramHtml } from "./lib/telegram-format-html.ts";
-import { addIndent, truncateString } from "./lib/utils.ts";
+import { addIndent, sleep, truncateString } from "./lib/utils.ts";
 import { getVersion } from "./lib/version.ts";
 
 async function main() {
@@ -134,6 +133,20 @@ Options:
       }),
     );
 
+    const replyWithRetry = async (...args: Parameters<typeof ctx.reply>) => {
+      try {
+        return await ctx.reply(...args);
+      } catch (error) {
+        const retryAfter = getTelegramRetryAfter(error);
+        if (retryAfter === undefined) {
+          throw error;
+        }
+        console.error(`${label} reply failed. retrying after ${retryAfter}s`, error);
+        await sleep((retryAfter + 1) * 1000);
+        return await ctx.reply(...args);
+      }
+    };
+
     try {
       await handler.handle({
         sessionName,
@@ -144,7 +157,7 @@ Options:
         send: async (replyText) => {
           const html = markdownToTelegramHtml(replyText);
           try {
-            return await ctx.reply(html, {
+            return await replyWithRetry(html, {
               parse_mode: "HTML",
             });
           } catch (error) {
@@ -152,7 +165,7 @@ Options:
               throw error;
             }
             console.error(`${label} formatted reply failed; falling back to raw text:`, error);
-            return await ctx.reply(replyText);
+            return await replyWithRetry(replyText);
           }
         },
       });
@@ -160,14 +173,7 @@ Options:
     } catch (error) {
       console.error(`${label} (response error)`, error);
       const message = error instanceof Error ? error.message : String(error);
-      try {
-        await retryTelegram429Once({
-          label,
-          action: () => ctx.reply(`Error: ${truncateString(message, 200)}`),
-        });
-      } catch (replyError) {
-        console.error(`${label} error reply failed; giving up:`, replyError);
-      }
+      await replyWithRetry(`Error: ${truncateString(message, 200)}`);
     }
   });
 
@@ -189,28 +195,8 @@ function telegramSessionName(context: Context): string {
 }
 
 function getTelegramRetryAfter(error: unknown): number | undefined {
-  if (!(error instanceof GrammyError) || error.error_code !== 429) {
-    return;
-  }
-  return error.parameters.retry_after;
-}
-
-async function retryTelegram429Once<T>(options: {
-  label: string;
-  action: () => Promise<T>;
-}): Promise<T> {
-  try {
-    return await options.action();
-  } catch (error) {
-    const retryAfter = getTelegramRetryAfter(error);
-    if (retryAfter === undefined) {
-      throw error;
-    }
-
-    const delaySeconds = retryAfter + 1;
-    console.warn(`${options.label} telegram flood control; retrying in ${delaySeconds}s:`, error);
-    await sleep(delaySeconds * 1000);
-    return await options.action();
+  if (error instanceof GrammyError && error.error_code === 429) {
+    return error.parameters.retry_after;
   }
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -137,8 +137,9 @@ Options:
       try {
         return await ctx.reply(...args);
       } catch (error) {
+        // rethrow non rate limit errors
         const retryAfter = getTelegramRetryAfter(error);
-        if (retryAfter === undefined) {
+        if (!retryAfter) {
           throw error;
         }
         console.error(`${label} reply failed. retrying...`, {
@@ -165,7 +166,8 @@ Options:
               parse_mode: "HTML",
             });
           } catch (error) {
-            if (getTelegramRetryAfter(error) !== undefined) {
+            // rethrow rate limit errors
+            if (getTelegramRetryAfter(error)) {
               throw error;
             }
             console.error(`${label} formatted reply failed; falling back to raw text:`, error);
@@ -175,6 +177,10 @@ Options:
       });
       console.log(`${label} (response ok)`);
     } catch (error) {
+      if (getTelegramRetryAfter(error)) {
+        console.error(`${label} reply failed due to rate limit.`, error);
+        return;
+      }
       console.error(`${label} (response error)`, error);
       const message = error instanceof Error ? error.message : String(error);
       await replyWithRetry(`Error: ${truncateString(message, 200)}`);

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -18,3 +18,5 @@ export function objectPickBy<K extends PropertyKey, V>(
 ): Record<K, V> {
   return Object.fromEntries(Object.entries(o).filter(([k, v]: any[]) => f(v, k))) as any;
 }
+
+export const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));


### PR DESCRIPTION
## Summary
- add sanitized Telegram error summaries in cli.ts
- avoid raw-text fallback when formatted Telegram replies hit 429
- retry catch-path error replies once after retry_after + 1s
- add bot.catch logging without replying or dumping full context

Fixes #53

## Testing
- Not run per request.