### PR TITLE
refactor: apply constructor options pattern

### DIFF
--- a/src/acp/index.ts
+++ b/src/acp/index.ts
@@ -16,23 +16,21 @@ import { objectPickBy } from "../lib/utils.ts";
 // this is likey more robust without acp agent capability assumption
 // and process startup time is negligible compared to LLM interaction itself
 
-type AgentManagerOptions = {
-  command: string;
-  cwd: string;
-};
-
 export class AgentManager {
-  option: AgentManagerOptions;
+  options: {
+    command: string;
+    cwd: string;
+  };
 
-  constructor(options: AgentManagerOptions) {
-    this.option = options;
+  constructor(options: AgentManager["options"]) {
+    this.options = options;
   }
 
   // TODO:
   // cwd and sessionCwd are always same
   // but they are explicitly specified for now
   async newSession({ sessionCwd }: { sessionCwd: string }) {
-    const agent = await spawnAgent(this.option);
+    const agent = await spawnAgent(this.options);
     const response = await agent.connection.newSession({
       cwd: sessionCwd,
       mcpServers: [],
@@ -41,7 +39,7 @@ export class AgentManager {
   }
 
   async loadSession({ sessionCwd, sessionId }: { sessionCwd: string; sessionId: string }) {
-    const agent = await spawnAgent(this.option);
+    const agent = await spawnAgent(this.options);
     await agent.connection.loadSession({
       sessionId,
       cwd: sessionCwd,
@@ -51,7 +49,7 @@ export class AgentManager {
   }
 
   async closeSession({ sessionId }: { sessionId: string }): Promise<void> {
-    const agent = await spawnAgent(this.option);
+    const agent = await spawnAgent(this.options);
     try {
       await agent.connection.unstable_closeSession({ sessionId });
     } finally {
@@ -60,9 +58,9 @@ export class AgentManager {
   }
 
   async listSessions(): Promise<ListSessionsResponse> {
-    const agent = await spawnAgent(this.option);
+    const agent = await spawnAgent(this.options);
     try {
-      return await agent.connection.listSessions({ cwd: this.option.cwd });
+      return await agent.connection.listSessions({ cwd: this.options.cwd });
     } finally {
       agent.stop();
     }

--- a/src/cron/store.ts
+++ b/src/cron/store.ts
@@ -107,17 +107,15 @@ export type CronDeliveryTarget = z.infer<typeof CronDeliveryTargetSchema>;
 export type CronRun = z.infer<typeof cronRunSchema>;
 type CronRunExtra = CronRun & { cronId: string };
 
-interface CronStoreOptions {
-  cronFile: string;
-  cronStateFile: string;
-}
-
 export class CronStore {
-  options: CronStoreOptions;
+  options: {
+    cronFile: string;
+    cronStateFile: string;
+  };
   jobFile: FileStateManager<CronJobFile>;
   stateFile: FileStateManager<CronStateFile>;
 
-  constructor(options: CronStoreOptions) {
+  constructor(options: CronStore["options"]) {
     this.options = { ...options };
     this.jobFile = new FileStateManager({
       file: options.cronFile,

--- a/src/cron/timer.ts
+++ b/src/cron/timer.ts
@@ -11,17 +11,15 @@ export interface CronDueEvent {
   scheduledAt: number;
 }
 
-export interface CronSchedulerOptions {
-  entries: CronTimerEntry[];
-  onDue: (event: CronDueEvent) => void;
-}
-
 export class CronScheduler {
   timers: Record<string, CronTimer> = {};
-  options: CronSchedulerOptions;
+  options: {
+    entries: CronTimerEntry[];
+    onDue: (event: CronDueEvent) => void;
+  };
   stopped = true;
 
-  constructor(options: CronSchedulerOptions) {
+  constructor(options: CronScheduler["options"]) {
     this.options = { ...options };
   }
 
@@ -64,17 +62,15 @@ export class CronScheduler {
   }
 }
 
-export interface CronTimerOptions {
-  entry: CronTimerEntry;
-  onDue: (event: CronDueEvent) => void;
-}
-
 export class CronTimer {
-  options: CronTimerOptions;
+  options: {
+    entry: CronTimerEntry;
+    onDue: (event: CronDueEvent) => void;
+  };
   timeout?: ReturnType<typeof setTimeout>;
   scheduledAt?: number;
 
-  constructor(options: CronTimerOptions) {
+  constructor(options: CronTimer["options"]) {
     this.options = { ...options };
   }
 

--- a/src/lib/utils-node.ts
+++ b/src/lib/utils-node.ts
@@ -13,17 +13,15 @@ export function readJsonFile<T>(file: string, defaultValue?: () => T): T {
   return defaultValue();
 }
 
-type FileStateManagerOptions<T> = {
-  file: string;
-  parse: (data: unknown) => T;
-  defaultValue: () => T;
-};
-
 export class FileStateManager<T> {
-  options: FileStateManagerOptions<T>;
+  options: {
+    file: string;
+    parse: (data: unknown) => T;
+    defaultValue: () => T;
+  };
   state: T;
 
-  constructor(options: FileStateManagerOptions<T>) {
+  constructor(options: FileStateManager<T>["options"]) {
     this.options = options;
     this.state = this.read();
   }


### PR DESCRIPTION
- closes https://github.com/hi-ogawa/acpella/issues/85

## Summary
- move constructor option shapes onto class `options` fields
- type constructors with `Class["options"]` for AgentManager, cron timer/store classes, and FileStateManager

## Test
- pnpm lint