### PR TITLE
fix: include session key in acp update logs

### DIFF
--- a/src/handler.test.ts
+++ b/src/handler.test.ts
@@ -361,6 +361,20 @@ test("verbose command toggles tool call output", async () => {
     `);
 });
 
+test("acp update logs include session name", async () => {
+  const tester = await createHandlerTester();
+  const session = tester.createSession("tg-123");
+  const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+  try {
+    await session.request("__tool:Read files");
+  } finally {
+    logSpy.mockRestore();
+  }
+
+  expect(logSpy.mock.calls).toContainEqual(["[tg-123] [acp:update] tool_call: Read files"]);
+});
+
 test("agent command", async () => {
   const tester = await createHandlerTester();
   const session = tester.createSession("test");

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -165,17 +165,20 @@ export async function createHandler(
     try {
       const result = session.prompt(promptText);
       activeSessions.set(sessionName, session);
+      const updateLogLabel = `[${sessionName}] [acp:update]`;
 
       for await (const update of result.consume()) {
         if (update.sessionUpdate === "agent_message_chunk" && update.content.type === "text") {
           await options.onText(update.content.text);
         } else if (update.sessionUpdate === "tool_call") {
-          console.log(`[acp:update] tool_call: ${update.title}`);
+          console.log(`${updateLogLabel} tool_call: ${update.title}`);
           await options.onToolCall?.(update.title, stateSession);
         } else if (update.sessionUpdate === "usage_update") {
-          console.log(`[acp:update] usage_update: (used: ${update.used}, size: ${update.size})`);
+          console.log(
+            `${updateLogLabel} usage_update: (used: ${update.used}, size: ${update.size})`,
+          );
         } else {
-          console.log(`[acp:update] ${update.sessionUpdate}`);
+          console.log(`${updateLogLabel} ${update.sessionUpdate}`);
         }
       }
       return { cancelled: cancelledSessions.has(session) };


### PR DESCRIPTION
## Summary
- prefix ACP update logs with the chat-level session name
- cover the new log format with a focused handler test
- keep the existing `[acp:update]` marker so log queries still work

## Testing
- `git diff --check -- src/handler.ts src/handler.test.ts`
- unable to run `pnpm test -- src/handler.test.ts` in `acpella-wt` because that worktree has no `node_modules`
