### PR TITLE
fix: show scoped help for grouped commands

### DIFF
--- a/src/handler.test.ts
+++ b/src/handler.test.ts
@@ -305,7 +305,8 @@ test("service commands", async () => {
   const session = tester.createSession("test");
   expect(await session.request("/service")).toMatchInlineSnapshot(`
     "[⚙️ System]
-    Usage: /service exit"
+    /service
+      /service exit - Exit acpella."
   `);
   await session.request("/service exit");
   expect(tester.onServiceExit.mock.calls).toMatchInlineSnapshot(`
@@ -391,12 +392,21 @@ test("session commands", async () => {
   const session = tester.createSession("test");
   expect(await session.request("/session")).toMatchInlineSnapshot(`
     "[⚙️ System]
-    Usage:
-    /session current
-    /session list
-    /session new [agent]
-    /session load <sessionId|agent:sessionId>
-    /session close [sessionId|agent:sessionId]"
+    /session
+      /session current - Show the current session.
+      /session list - List known agent sessions.
+      /session new [agent] - Start a new agent session.
+      /session load <sessionId|agent:sessionId> - Load an existing agent session.
+      /session close [sessionId|agent:sessionId] - Close an agent session."
+  `);
+  expect(await session.request("/session help")).toMatchInlineSnapshot(`
+    "[⚙️ System]
+    /session
+      /session current - Show the current session.
+      /session list - List known agent sessions.
+      /session new [agent] - Start a new agent session.
+      /session load <sessionId|agent:sessionId> - Load an existing agent session.
+      /session close [sessionId|agent:sessionId] - Close an agent session."
   `);
   expect(await session.request("/session current")).toMatchInlineSnapshot(`
     "[⚙️ System]
@@ -418,6 +428,10 @@ test("session commands", async () => {
   expect(await session.request("/session list")).toMatchInlineSnapshot(`
     "[⚙️ System]
     - test -> test:__testSession1 (active)"
+  `);
+  expect(await session.request("/session load")).toMatchInlineSnapshot(`
+    "[⚙️ System]
+    Usage: /session load <sessionId|agent:sessionId>"
   `);
   expect(await session.request("/session new")).toMatchInlineSnapshot(`
     "[⚙️ System]
@@ -549,11 +563,11 @@ test("agent command", async () => {
   const session = tester.createSession("test");
   expect(await session.request("/agent")).toMatchInlineSnapshot(`
     "[⚙️ System]
-    Usage:
-    /agent list
-    /agent new <name> <command...>
-    /agent remove <name>
-    /agent default [name]"
+    /agent
+      /agent list - List configured agents.
+      /agent new <name> <command...> - Save a new agent.
+      /agent remove <name> - Remove an agent.
+      /agent default [name] - Show or set the default agent."
   `);
   expect(await session.request("/agent list")).toMatchInlineSnapshot(`
     "[⚙️ System]

--- a/src/lib/command.test.ts
+++ b/src/lib/command.test.ts
@@ -63,13 +63,16 @@ describe(createCommandHandler, () => {
         "test:pong",
         "/config
         /config show - Show config.
-        /config set <value...> - Set config.",
+        /config set <value...> - Set config.
+      ",
         "/config
         /config show - Show config.
-        /config set <value...> - Set config.",
+        /config set <value...> - Set config.
+      ",
         "/config
         /config show - Show config.
-        /config set <value...> - Set config.",
+        /config set <value...> - Set config.
+      ",
         "test:set:theme dark",
         "Commands:
       /help - Show command help.
@@ -79,7 +82,9 @@ describe(createCommandHandler, () => {
 
       /config
         /config show - Show config.
-        /config set <value...> - Set config.",
+        /config set <value...> - Set config.
+
+      ",
       ]
     `);
   });

--- a/src/lib/command.test.ts
+++ b/src/lib/command.test.ts
@@ -67,9 +67,9 @@ describe(createCommandHandler, () => {
         "/config
         /config show - Show config.
         /config set <value...> - Set config.",
-        "Usage:
-      /config show
-      /config set <value...>",
+        "/config
+        /config show - Show config.
+        /config set <value...> - Set config.",
         "test:set:theme dark",
         "Commands:
       /help - Show command help.

--- a/src/lib/command.test.ts
+++ b/src/lib/command.test.ts
@@ -53,12 +53,20 @@ describe(createCommandHandler, () => {
     expect(await commandHandler.handle({ text: "/missing", context })).toBe(false);
     expect(await commandHandler.handle({ text: "/ping", context })).toBe(true);
     expect(await commandHandler.handle({ text: "/config", context })).toBe(true);
+    expect(await commandHandler.handle({ text: "/config help", context })).toBe(true);
+    expect(await commandHandler.handle({ text: "/config missing", context })).toBe(true);
     expect(await commandHandler.handle({ text: "/config set theme dark", context })).toBe(true);
     expect(await commandHandler.handle({ text: "/help", context })).toBe(true);
 
     expect(events).toMatchInlineSnapshot(`
       [
         "test:pong",
+        "/config
+        /config show - Show config.
+        /config set <value...> - Set config.",
+        "/config
+        /config show - Show config.
+        /config set <value...> - Set config.",
         "Usage:
       /config show
       /config set <value...>",

--- a/src/lib/command.ts
+++ b/src/lib/command.ts
@@ -16,6 +16,7 @@ export function createCommandHandler<T>(options: {
   onUsage: (usage: string, context: T) => Promise<void>;
 }) {
   const usageByCommand = buildUsageByCommand(options.commands);
+  const helpByCommand = buildHelpByCommand(options.commands);
   const commandOverview = renderCommandOverview(options.commands);
 
   return {
@@ -37,7 +38,10 @@ export function createCommandHandler<T>(options: {
 
       const matched = findCommand(commandGroup, subcommandTokens);
       if (!matched) {
-        await options.onUsage(usageByCommand[commandName]!, handleOptions.context);
+        const output = isGroupHelpRequest(subcommandTokens)
+          ? helpByCommand[commandName]!
+          : usageByCommand[commandName]!;
+        await options.onUsage(output, handleOptions.context);
         return true;
       }
 
@@ -96,6 +100,14 @@ function buildUsageByCommand<T>(commands: CommandTree<T>): Record<string, string
   return usageByCommand;
 }
 
+function buildHelpByCommand<T>(commands: CommandTree<T>): Record<string, string> {
+  const helpByCommand: Record<string, string> = {};
+  for (const [command, commandGroup] of Object.entries(commands)) {
+    helpByCommand[command] = renderCommandHelp(command, commandGroup);
+  }
+  return helpByCommand;
+}
+
 function renderCommandUsage<T>(commands: CommandSpec<T>[]): string {
   const usages = commands.map((command) => getCommandUsage(command));
   if (usages.length === 1) {
@@ -108,13 +120,22 @@ function getCommandUsage<T>(command: CommandSpec<T>): string {
   return command.help.split(" - ", 1)[0]!;
 }
 
+function renderCommandHelp<T>(commandName: string, commands: CommandSpec<T>[]): string {
+  let output = `/${commandName}`;
+  for (const command of commands) {
+    output += `\n  ${command.help}`;
+  }
+  return output;
+}
+
 function renderCommandOverview<T>(commands: CommandTree<T>): string {
   let output = "Commands:\n/help - Show command help.";
   for (const [command, commandGroup] of Object.entries(commands)) {
-    output += `\n\n/${command}`;
-    for (const commandSpec of commandGroup) {
-      output += `\n  ${commandSpec.help}`;
-    }
+    output += `\n\n${renderCommandHelp(command, commandGroup)}`;
   }
   return output;
+}
+
+function isGroupHelpRequest(tokens: string[]): boolean {
+  return tokens.length === 0 || (tokens.length === 1 && tokens[0] === "help");
 }

--- a/src/lib/command.ts
+++ b/src/lib/command.ts
@@ -15,7 +15,6 @@ export function createCommandHandler<T>(options: {
   commands: CommandTree<T>;
   onUsage: (usage: string, context: T) => Promise<void>;
 }) {
-  const usageByCommand = buildUsageByCommand(options.commands);
   const helpByCommand = buildHelpByCommand(options.commands);
   const commandOverview = renderCommandOverview(options.commands);
 
@@ -38,10 +37,7 @@ export function createCommandHandler<T>(options: {
 
       const matched = findCommand(commandGroup, subcommandTokens);
       if (!matched) {
-        const output = isGroupHelpRequest(subcommandTokens)
-          ? helpByCommand[commandName]!
-          : usageByCommand[commandName]!;
-        await options.onUsage(output, handleOptions.context);
+        await options.onUsage(helpByCommand[commandName]!, handleOptions.context);
         return true;
       }
 
@@ -92,32 +88,12 @@ function isEqualArray(left: string[], right: string[]): boolean {
   return left.length === right.length && isPrefixArray(left, right);
 }
 
-function buildUsageByCommand<T>(commands: CommandTree<T>): Record<string, string> {
-  const usageByCommand: Record<string, string> = {};
-  for (const [command, commandGroup] of Object.entries(commands)) {
-    usageByCommand[command] = renderCommandUsage(commandGroup);
-  }
-  return usageByCommand;
-}
-
 function buildHelpByCommand<T>(commands: CommandTree<T>): Record<string, string> {
   const helpByCommand: Record<string, string> = {};
   for (const [command, commandGroup] of Object.entries(commands)) {
     helpByCommand[command] = renderCommandHelp(command, commandGroup);
   }
   return helpByCommand;
-}
-
-function renderCommandUsage<T>(commands: CommandSpec<T>[]): string {
-  const usages = commands.map((command) => getCommandUsage(command));
-  if (usages.length === 1) {
-    return `Usage: ${usages[0]}`;
-  }
-  return `Usage:\n${usages.join("\n")}`;
-}
-
-function getCommandUsage<T>(command: CommandSpec<T>): string {
-  return command.help.split(" - ", 1)[0]!;
 }
 
 function renderCommandHelp<T>(commandName: string, commands: CommandSpec<T>[]): string {
@@ -134,8 +110,4 @@ function renderCommandOverview<T>(commands: CommandTree<T>): string {
     output += `\n\n${renderCommandHelp(command, commandGroup)}`;
   }
   return output;
-}
-
-function isGroupHelpRequest(tokens: string[]): boolean {
-  return tokens.length === 0 || (tokens.length === 1 && tokens[0] === "help");
 }

--- a/src/lib/command.ts
+++ b/src/lib/command.ts
@@ -16,7 +16,10 @@ export function createCommandHandler<T>(options: {
   onUsage: (usage: string, context: T) => Promise<void>;
 }) {
   const helpByCommand = buildHelpByCommand(options.commands);
-  const commandOverview = renderCommandOverview(options.commands);
+  const commandOverview = [
+    "Commands:\n/help - Show command help.",
+    ...Object.values(helpByCommand),
+  ].join("\n\n");
 
   return {
     async handle(handleOptions: { text: string; context: T }): Promise<boolean> {
@@ -100,14 +103,6 @@ function renderCommandHelp<T>(commandName: string, commands: CommandSpec<T>[]): 
   let output = `/${commandName}`;
   for (const command of commands) {
     output += `\n  ${command.help}`;
-  }
-  return output;
-}
-
-function renderCommandOverview<T>(commands: CommandTree<T>): string {
-  let output = "Commands:\n/help - Show command help.";
-  for (const [command, commandGroup] of Object.entries(commands)) {
-    output += `\n\n${renderCommandHelp(command, commandGroup)}`;
   }
   return output;
 }

--- a/src/lib/command.ts
+++ b/src/lib/command.ts
@@ -15,7 +15,12 @@ export function createCommandHandler<T>(options: {
   commands: CommandTree<T>;
   onUsage: (usage: string, context: T) => Promise<void>;
 }) {
-  const helpByCommand = buildHelpByCommand(options.commands);
+  const helpByCommand = Object.fromEntries(
+    Object.entries(options.commands).map(([command, commandGroup]) => [
+      command,
+      renderCommandHelp(command, commandGroup),
+    ]),
+  );
   const commandOverview = [
     "Commands:\n/help - Show command help.",
     ...Object.values(helpByCommand),
@@ -89,14 +94,6 @@ function isPrefixArray(left: string[], right: string[]): boolean {
 
 function isEqualArray(left: string[], right: string[]): boolean {
   return left.length === right.length && isPrefixArray(left, right);
-}
-
-function buildHelpByCommand<T>(commands: CommandTree<T>): Record<string, string> {
-  const helpByCommand: Record<string, string> = {};
-  for (const [command, commandGroup] of Object.entries(commands)) {
-    helpByCommand[command] = renderCommandHelp(command, commandGroup);
-  }
-  return helpByCommand;
 }
 
 function renderCommandHelp<T>(commandName: string, commands: CommandSpec<T>[]): string {

--- a/src/lib/command.ts
+++ b/src/lib/command.ts
@@ -99,9 +99,7 @@ ${subCommands.map((c) => `  ${c.help}`).join("\n")}
 Commands:
 /help - Show command help.
 
-${Object.values(byCommand)
-  .map((c) => c)
-  .join("\n")}
+${Object.values(byCommand).join("\n")}
 `;
   return { full, byCommand };
 }

--- a/src/lib/command.ts
+++ b/src/lib/command.ts
@@ -15,16 +15,7 @@ export function createCommandHandler<T>(options: {
   commands: CommandTree<T>;
   onUsage: (usage: string, context: T) => Promise<void>;
 }) {
-  const helpByCommand = Object.fromEntries(
-    Object.entries(options.commands).map(([command, commandGroup]) => [
-      command,
-      renderCommandHelp(command, commandGroup),
-    ]),
-  );
-  const commandOverview = [
-    "Commands:\n/help - Show command help.",
-    ...Object.values(helpByCommand),
-  ].join("\n\n");
+  const help = buildHelp(options.commands);
 
   return {
     async handle(handleOptions: { text: string; context: T }): Promise<boolean> {
@@ -34,7 +25,7 @@ export function createCommandHandler<T>(options: {
       }
       const [commandName, ...subcommandTokens] = tokens;
       if (commandName === "help") {
-        await options.onUsage(commandOverview, handleOptions.context);
+        await options.onUsage(help.full, handleOptions.context);
         return true;
       }
 
@@ -45,7 +36,7 @@ export function createCommandHandler<T>(options: {
 
       const matched = findCommand(commandGroup, subcommandTokens);
       if (!matched) {
-        await options.onUsage(helpByCommand[commandName]!, handleOptions.context);
+        await options.onUsage(help.byCommand[commandName]!, handleOptions.context);
         return true;
       }
 
@@ -96,10 +87,21 @@ function isEqualArray(left: string[], right: string[]): boolean {
   return left.length === right.length && isPrefixArray(left, right);
 }
 
-function renderCommandHelp<T>(commandName: string, commands: CommandSpec<T>[]): string {
-  let output = `/${commandName}`;
-  for (const command of commands) {
-    output += `\n  ${command.help}`;
+function buildHelp(tree: CommandTree<any>) {
+  const byCommand: Record<string, string> = {};
+  for (const [command, subCommands] of Object.entries(tree)) {
+    byCommand[command] = `\
+/${command}
+${subCommands.map((c) => `  ${c.help}`).join("\n")}
+`;
   }
-  return output;
+  const full = `\
+Commands:
+/help - Show command help.
+
+${Object.values(byCommand)
+  .map((c) => c)
+  .join("\n")}
+`;
+  return { full, byCommand };
 }


### PR DESCRIPTION
## Summary
- treat bare grouped commands like `/session` and `/agent` as scoped help instead of usage-only fallback
- support `/session help`-style requests while preserving terse usage for malformed subcommands
- update command and handler snapshots for the new generic behavior

## Testing
- pnpm test -- src/lib/command.test.ts src/handler.test.ts