### PR TITLE
refactor: simplify cli error

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -31,33 +31,30 @@ Options:
 `;
 
 async function main() {
-  const cli = parseCli({
-    argv: process.argv,
-    commands: ["serve", "repl", "exec"],
-    defaultCommand: "serve",
-  });
-
-  if (cli.command === "help") {
+  const cliArgv = process.argv.slice(2);
+  if (["-h", "--help"].includes(cliArgv[0])) {
     console.log(CLI_HELP);
     return;
   }
 
+  const cli = parseCli({
+    argv: cliArgv,
+    commands: ["serve", "repl", "exec"],
+    defaultCommand: "serve",
+  });
+
   if (cli.command !== "exec" && cli.args.length > 0) {
-    console.error(`\
+    throw new Error(`\
 Unexpected arguments for ${cli.command}: ${cli.args.join(" ")}
 
 ${CLI_HELP}`);
-    process.exitCode = 1;
-    return;
   }
 
   if (cli.command === "exec" && cli.args.length === 0) {
-    console.error(`\
+    throw new Error(`\
 Missing message for exec
 
 ${CLI_HELP}`);
-    process.exitCode = 1;
-    return;
   }
 
   const config = loadConfig();
@@ -125,14 +122,10 @@ ${CLI_HELP}`);
   const allowedChats = new Set(config.telegram.allowedChatIds);
 
   if (!config.telegram.token) {
-    console.error("ACPELLA_TELEGRAM_BOT_TOKEN is required");
-    process.exitCode = 1;
-    return;
+    throw new Error("ACPELLA_TELEGRAM_BOT_TOKEN is required");
   }
   if (allowedUsers.size === 0) {
-    console.error("ACPELLA_TELEGRAM_ALLOWED_USER_IDS must be non-empty");
-    process.exitCode = 1;
-    return;
+    throw new Error("ACPELLA_TELEGRAM_ALLOWED_USER_IDS must be non-empty");
   }
 
   const bot = new Bot(config.telegram.token);

--- a/src/e2e/basic.test.ts
+++ b/src/e2e/basic.test.ts
@@ -20,18 +20,17 @@ test("help", async () => {
   `);
 });
 
+function sanitizeCliError(error: Error) {
+  return sanitizeOutput(error.message)
+    .replaceAll(/    at .*\n/g, "")
+    .trim();
+}
+
 test("cli error", async () => {
   const cli = useCli();
-  await expect(cli.cli("yay")).rejects.toThrowErrorMatchingInlineSnapshot(`
-    [Error: Command failed: pnpm -s cli blabla
-    Error: Unknown command: blabla
-        at parseCli (file:///home/hiroshi/code/personal/acpella/src/lib/cli.ts:17:11)
-        at main (file:///home/hiroshi/code/personal/acpella/src/cli.ts:40:15)
-        at file:///home/hiroshi/code/personal/acpella/src/cli.ts:355:1
-        at ModuleJob.run (node:internal/modules/esm/module_job:430:25)
-        at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:661:26)
-        at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:101:5)
-    ]
+  await expect(cli.cli("yay").catch(sanitizeCliError)).resolves.toThrowErrorMatchingInlineSnapshot(`
+    "Command failed: pnpm -s cli yay
+    Error: Unknown command: yay"
   `);
 });
 
@@ -86,18 +85,11 @@ describe("exec", async () => {
 
   test("hard error", async () => {
     const cli = useCli();
-    await expect(cli.cli("exec", "/session load error-agent:error-session")).rejects.toSatisfy(
-      (e) => {
-        expect.assert(e instanceof Error);
-        expect(sanitizeOutput(e.message).split("\n").slice(0, 2)).toMatchInlineSnapshot(`
-        [
-          "Command failed: pnpm -s cli exec /session load error-agent:error-session",
-          "Error: Unknown agent: error-agent",
-        ]
-      `);
-        return true;
-      },
-    );
+    await expect(cli.cli("exec", "/session load error-agent:error-session").catch(sanitizeCliError))
+      .resolves.toMatchInlineSnapshot(`
+      "Command failed: pnpm -s cli exec /session load error-agent:error-session
+      Error: Unknown agent: error-agent"
+    `);
   });
 
   test("soft error", async () => {

--- a/src/e2e/basic.test.ts
+++ b/src/e2e/basic.test.ts
@@ -20,6 +20,21 @@ test("help", async () => {
   `);
 });
 
+test("cli error", async () => {
+  const cli = useCli();
+  await expect(cli.cli("yay")).rejects.toThrowErrorMatchingInlineSnapshot(`
+    [Error: Command failed: pnpm -s cli blabla
+    Error: Unknown command: blabla
+        at parseCli (file:///home/hiroshi/code/personal/acpella/src/lib/cli.ts:17:11)
+        at main (file:///home/hiroshi/code/personal/acpella/src/cli.ts:40:15)
+        at file:///home/hiroshi/code/personal/acpella/src/cli.ts:355:1
+        at ModuleJob.run (node:internal/modules/esm/module_job:430:25)
+        at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:661:26)
+        at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:101:5)
+    ]
+  `);
+});
+
 describe("repl", () => {
   test("basic", async () => {
     const service = startService();
@@ -83,5 +98,16 @@ describe("exec", async () => {
         return true;
       },
     );
+  });
+
+  test("soft error", async () => {
+    const cli = useCli();
+    const result = await cli.cli("exec", "/agent default boo");
+    expect(sanitizeOutput(result.stderr)).toMatchInlineSnapshot(`""`);
+    expect(result.stdout).toMatchInlineSnapshot(`
+      "[⚙️ System]
+      Unknown agent: boo
+      "
+    `);
   });
 });

--- a/src/lib/cli.ts
+++ b/src/lib/cli.ts
@@ -8,7 +8,7 @@ export function parseCli(options: {
   commands: string[];
   defaultCommand?: string;
 }): ParsedCli {
-  const [inputCommand, ...args] = options.argv.slice(2);
+  const [inputCommand, ...args] = options.argv;
   const command = inputCommand ?? options.defaultCommand;
   if (!command) {
     throw new Error("Missing command");

--- a/src/lib/cli.ts
+++ b/src/lib/cli.ts
@@ -10,13 +10,6 @@ export function parseCli(options: {
 }): ParsedCli {
   const [inputCommand, ...args] = options.argv.slice(2);
   const command = inputCommand ?? options.defaultCommand;
-
-  if (command === "-h" || command === "--help") {
-    return {
-      command: "help",
-      args: [],
-    };
-  }
   if (!command) {
     throw new Error("Missing command");
   }


### PR DESCRIPTION
Let's prefer `throw new Error` over  `console.error + process.exitCode = 1` since it gives stack trace for free.