### PR TITLE
test: advance timer by fixed time

### DIFF
--- a/src/cron/timer.test.ts
+++ b/src/cron/timer.test.ts
@@ -70,9 +70,9 @@ test(CronTimer, ({ onTestFinished }) => {
   });
 
   // timer internally set timeout at most 1 minute
-  vi.advanceTimersToNextTimer();
+  vi.advanceTimersByTime(60 * 1000);
   expect(events).toMatchInlineSnapshot(`[]`);
-  vi.advanceTimersToNextTimer();
+  vi.advanceTimersByTime(60 * 1000);
   expect(events).toMatchInlineSnapshot(`
     [
       {
@@ -81,7 +81,7 @@ test(CronTimer, ({ onTestFinished }) => {
       },
     ]
   `);
-  vi.advanceTimersToNextTimer();
+  vi.advanceTimersByTime(60 * 1000);
   expect(events).toMatchInlineSnapshot(`
     [
       {
@@ -90,7 +90,7 @@ test(CronTimer, ({ onTestFinished }) => {
       },
     ]
   `);
-  vi.advanceTimersToNextTimer();
+  vi.advanceTimersByTime(60 * 1000);
   expect(events).toMatchInlineSnapshot(`
     [
       {

--- a/src/handler.test.ts
+++ b/src/handler.test.ts
@@ -842,10 +842,7 @@ test("cron reload command", async ({ onTestFinished }) => {
       last: none"
   `);
 
-  vi.advanceTimersByTime(60 * 1000);
-  vi.advanceTimersByTime(60 * 1000);
-  // vi.advanceTimersToNextTimer()
-  // vi.advanceTimersToNextTimer()
+  vi.advanceTimersByTime(2 * 60 * 1000);
   expect(formatTime(Date.now(), tester.config.timezone)).toMatchInlineSnapshot(
     `"2026-04-18T07:02:00+07:00"`,
   );
@@ -1028,8 +1025,7 @@ test("cron command", async ({ onTestFinished }) => {
       last: none"
   `);
 
-  vi.advanceTimersByTime(60 * 1000);
-  vi.advanceTimersByTime(60 * 1000);
+  vi.advanceTimersByTime(2 * 60 * 1000);
   expect(formatTime(Date.now(), tester.config.timezone)).toMatchInlineSnapshot(
     `"2026-04-18T07:03:00+07:00"`,
   );

--- a/src/handler.test.ts
+++ b/src/handler.test.ts
@@ -842,8 +842,10 @@ test("cron reload command", async ({ onTestFinished }) => {
       last: none"
   `);
 
-  vi.advanceTimersToNextTimer();
-  vi.advanceTimersToNextTimer();
+  vi.advanceTimersByTime(60 * 1000);
+  vi.advanceTimersByTime(60 * 1000);
+  // vi.advanceTimersToNextTimer()
+  // vi.advanceTimersToNextTimer()
   expect(formatTime(Date.now(), tester.config.timezone)).toMatchInlineSnapshot(
     `"2026-04-18T07:02:00+07:00"`,
   );
@@ -950,7 +952,7 @@ test("cron command", async ({ onTestFinished }) => {
   `);
   expect(tester.cronDeliveries).toMatchInlineSnapshot(`[]`);
 
-  vi.advanceTimersToNextTimer();
+  vi.advanceTimersByTime(60 * 1000);
   expect(formatTime(Date.now(), tester.config.timezone)).toMatchInlineSnapshot(
     `"2026-04-18T07:01:00+07:00"`,
   );
@@ -1026,8 +1028,8 @@ test("cron command", async ({ onTestFinished }) => {
       last: none"
   `);
 
-  vi.advanceTimersToNextTimer();
-  vi.advanceTimersToNextTimer();
+  vi.advanceTimersByTime(60 * 1000);
+  vi.advanceTimersByTime(60 * 1000);
   expect(formatTime(Date.now(), tester.config.timezone)).toMatchInlineSnapshot(
     `"2026-04-18T07:03:00+07:00"`,
   );
@@ -1085,7 +1087,7 @@ test("cron command", async ({ onTestFinished }) => {
     Updated cron job: other-job"
   `);
 
-  vi.advanceTimersToNextTimer();
+  vi.advanceTimersByTime(60 * 1000);
   expect(formatTime(Date.now(), tester.config.timezone)).toMatchInlineSnapshot(
     `"2026-04-18T07:04:00+07:00"`,
   );
@@ -1210,7 +1212,7 @@ test("cron error delivery", async ({ onTestFinished }) => {
   `);
   expect(tester.cronDeliveries).toMatchInlineSnapshot(`[]`);
 
-  vi.advanceTimersToNextTimer();
+  vi.advanceTimersByTime(60 * 1000);
   expect(formatTime(Date.now(), tester.config.timezone)).toMatchInlineSnapshot(
     `"2026-04-18T07:01:00+07:00"`,
   );


### PR DESCRIPTION
Currently we assume `vi.advanceTimersToNextTimer` to advance just 1 minute due to cron scheduler timer, but this might change in https://github.com/hi-ogawa/acpella/pull/126.