### PR TITLE
docs: align acpella skill with global CLI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,11 +9,14 @@
 
 ## Key Docs
 
-| File                         | Purpose                               |
-| ---------------------------- | ------------------------------------- |
-| `docs/architecture.md`       | Design decisions, data flow           |
-| `docs/references.md`         | Reference projects, local clone setup |
-| `docs/tasks/YYYY-MM-DD-*.md` | Per-task notes                        |
+| File                          | Purpose                               |
+| ----------------------------- | ------------------------------------- |
+| `README.md`                   | User-facing setup, global CLI, config |
+| `skills/acpella/SKILL.md`     | Operator/admin guide for agents       |
+| `skills/acpella/references/*` | Detailed acpella workflows            |
+| `docs/architecture.md`        | Design decisions, data flow           |
+| `docs/references.md`          | Reference projects, local clone setup |
+| `docs/tasks/YYYY-MM-DD-*.md`  | Per-task notes                        |
 
 ## Task Documents
 
@@ -38,6 +41,7 @@ Task docs should enable **handoff to a fresh agent** - include enough context to
 - Prefer a single options object over multiple primitive arguments (e.g. `fn({ a, b })` not `fn(a, b)`)
 - Import with `.ts` extensions (NodeNext resolution)
 - Use braces for every `switch` case body (`case "x": { ... }`, `default: { ... }`)
+- When changing setup, CLI commands, service management, session routing, agent registration, customization, cron, or troubleshooting behavior, check whether `README.md` and `skills/acpella` need matching updates.
 
 ## Rule
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ Task docs should enable **handoff to a fresh agent** - include enough context to
 - Reference files/patterns to follow
 - Implementation plan
 
-## Conventions
+## Rules
 
 - Commit messages: use Conventional Commits (`feat:`, `fix:`, `docs:`, `refactor:`, `chore:`); add `!` for breaking changes
 - File names: kebab-case
@@ -42,8 +42,4 @@ Task docs should enable **handoff to a fresh agent** - include enough context to
 - Import with `.ts` extensions (NodeNext resolution)
 - Use braces for every `switch` case body (`case "x": { ... }`, `default: { ... }`)
 - When changing setup, CLI commands, service management, session routing, agent registration, customization, cron, or troubleshooting behavior, check whether `README.md` and `skills/acpella` need matching updates.
-
-## Rule
-
-- Never remove `TODO: review slop` comment
 - Do not update existing `docs/tasks/*` notes just to reflect code refactors unless explicitly asked.

--- a/skills/acpella/SKILL.md
+++ b/skills/acpella/SKILL.md
@@ -14,7 +14,8 @@ Acpella is a small bridge from a messaging surface, currently Telegram or the lo
 ## Working model
 
 - Acpella source lives at https://github.com/hi-ogawa/acpella.
-- The acpella source checkout is where `pnpm cli` works and where service code is installed from.
+- The normal operator CLI is the globally linked `acpella` command, installed from the source checkout with `pnpm link --global`.
+- `pnpm cli` is a development fallback for running directly from the source checkout.
 - `ACPELLA_HOME` is the working directory acpella uses for agent sessions and acpella state.
 - Acpella stores its own state under `ACPELLA_HOME/.acpella/`, including session mappings, configured agents, cron jobs, logs, and optional custom instructions.
 - A Telegram chat/thread or REPL context maps to an acpella session name.
@@ -28,30 +29,30 @@ Use this skill when the task is about operating acpella itself: setup, service m
 
 Administrative slash commands use the same text syntax across Telegram, the local REPL, and local one-shot execution, but they run inside whichever acpella process receives them.
 
-When unsure which slash command or arguments to use, start with `/help` from Telegram, the local REPL, or `pnpm cli exec /help`. Treat it as the source of truth for the currently installed command surface.
+When unsure which slash command or arguments to use, start with `/help` from Telegram, the local REPL, or `acpella exec /help`. Treat it as the source of truth for the currently installed command surface.
 
 ## Command process scope
 
 - Telegram commands are handled by the long-running acpella bot service.
 - REPL commands are handled by that REPL process.
-- `pnpm cli exec <slash-command...>` starts a separate short-lived acpella process, handles one command, then exits.
+- `acpella exec <slash-command...>` starts a separate short-lived acpella process, handles one command, then exits.
 
 Commands that only read or mutate shared `.acpella` state, such as `/agent list`, `/session list`, `/cron add`, or `/cron update`, are usually fine through `exec`.
 
 Commands that control process-local runtime state, such as `/cron start`, `/cron stop`, `/session new`, `/session load`, or `/session close`, must be sent to the process whose runtime state should change. Do not use `exec` to control another running acpella service.
 
-Use `pnpm cli exec <slash-command...>` only for local shell administration of acpella itself: inspecting or changing installation-wide state, listing configured objects, or running setup commands.
+Use `acpella exec <slash-command...>` only for local shell administration of acpella itself: inspecting or changing installation-wide state, listing configured objects, or running setup commands.
 
-Command examples use `pnpm cli`, which assumes the shell is in the acpella source checkout. If the current directory is not the acpella checkout, first `cd` to the checkout that owns the running service, or replace `pnpm cli` with that installation's equivalent acpella CLI entrypoint.
+Command examples use `acpella`, which assumes the global CLI is linked to the checkout/version that owns the running service. If it is not, run `pnpm link --global` from the intended checkout or use that installation's equivalent acpella CLI entrypoint.
 
 Good `exec` examples:
 
 ```bash
-pnpm cli exec /status
-pnpm cli exec /agent list
-pnpm cli exec /session list
-pnpm cli exec /cron list
-pnpm cli exec /service systemd install
+acpella exec /status
+acpella exec /agent list
+acpella exec /session list
+acpella exec /cron list
+acpella exec /service systemd install
 ```
 
 Do not use `exec` to send normal agent prompts. Do not use `exec` for session lifecycle actions that depend on the current Telegram or REPL conversation context, such as `/session new`, `/session load`, or `/session close`. Use `/session list` and `/session info <sessionName>` through `exec` only to discover or inspect existing sessions for administrative commands such as cron creation.

--- a/skills/acpella/references/bootstrap.md
+++ b/skills/acpella/references/bootstrap.md
@@ -10,7 +10,9 @@ Clone the source from https://github.com/hi-ogawa/acpella:
 git clone https://github.com/hi-ogawa/acpella
 cd acpella
 pnpm install
-cp .env.example .env
+pnpm link --global
+mkdir -p ~/.config/acpella
+cp .env.example ~/.config/acpella/.env
 ```
 
 After copying `.env`, edit the main config values below.
@@ -26,29 +28,29 @@ After copying `.env`, edit the main config values below.
 
 Notes:
 
-- Telegram configuration is not required for `pnpm repl`.
+- Telegram configuration is not required for `acpella repl`.
 - If `ACPELLA_HOME/.acpella/AGENTS.md` exists, acpella sends it as custom instructions once when creating a new session.
 
 ## First local runs
 
-Run these from the acpella source checkout.
+Run these after linking the global CLI from the acpella source checkout.
 
 Run the Telegram bot:
 
 ```bash
-pnpm cli
+acpella serve
 ```
 
 Run the local REPL:
 
 ```bash
-pnpm repl
+acpella repl
 ```
 
 Run one local administrative slash command:
 
 ```bash
-pnpm cli exec /status
+acpella exec /status
 ```
 
 Use `exec` for acpella administration, not for normal agent prompts.
@@ -60,15 +62,15 @@ The built-in default agent is the test echo agent. Acpella does not install ACP 
 For Codex ACP without a global install, register the adapter through `npx`:
 
 ```bash
-pnpm cli exec /agent new codex npx -y @zed-industries/codex-acp
-pnpm cli exec /agent default codex
+acpella exec /agent new codex npx -y @zed-industries/codex-acp
+acpella exec /agent default codex
 ```
 
 If `codex-acp` is already installed and available on the same `PATH` used by acpella, you can register `codex-acp` directly instead:
 
 ```bash
 npm i -g @zed-industries/codex-acp
-pnpm cli exec /agent new codex codex-acp
+acpella exec /agent new codex codex-acp
 ```
 
 Other known ACP agents are listed in the ACP agent registry: https://agentclientprotocol.com/get-started/registry

--- a/skills/acpella/references/cron.md
+++ b/skills/acpella/references/cron.md
@@ -25,30 +25,30 @@ Use:
 
 The prompt must come after a literal `--` separator.
 
-When running `/cron add` through a shell with `pnpm cli exec`, quote the full slash command. Cron fields commonly contain `*`, and unquoted `*` can expand to filenames before acpella sees the command.
+When running `/cron add` through a shell with `acpella exec`, quote the full slash command. Cron fields commonly contain `*`, and unquoted `*` can expand to filenames before acpella sees the command.
 
 When adding a cron job from local shell administration, always provide `--session <sessionName>` so scheduled output can be delivered to Telegram:
 
 ```bash
-pnpm cli exec '/cron add morning-check 0 9 * * 1-5 --session tg-123456789 -- Check the project state and report anything urgent.'
+acpella exec '/cron add morning-check 0 9 * * 1-5 --session tg-123456789 -- Check the project state and report anything urgent.'
 ```
 
-`pnpm cli exec` runs in a separate short-lived acpella process. Add, update, enable, disable, and delete commands still write the shared cron file, and the running Telegram service should pick those file changes up automatically when its cron runner is active.
+`acpella exec` runs in a separate short-lived acpella process. Add, update, enable, disable, and delete commands still write the shared cron file, and the running Telegram service should pick those file changes up automatically when its cron runner is active.
 
 For Telegram topics, the session name includes the thread id:
 
 ```bash
-pnpm cli exec '/cron add topic-check 30 8 * * * --session tg-123456789-42 -- Send the morning topic summary.'
+acpella exec '/cron add topic-check 30 8 * * * --session tg-123456789-42 -- Send the morning topic summary.'
 ```
 
-The session must already exist in acpella state. Use `pnpm cli exec /session list` to find known session names. If the list does not clearly identify a single intended destination, ask the user to confirm the session before adding, deleting, or recreating the cron job.
+The session must already exist in acpella state. Use `acpella exec /session list` to find known session names. If the list does not clearly identify a single intended destination, ask the user to confirm the session before adding, deleting, or recreating the cron job.
 
 If `/cron add` is issued inside the Telegram conversation where the job should deliver, `--session` can be omitted because acpella can capture the current Telegram delivery target. Agents operating through local `exec` should not rely on that implicit capture.
 
 ## Common workflow
 
-1. Find the target session with `pnpm cli exec /session list` if creating the job from local shell administration; if more than one candidate could match, confirm with the user before continuing.
-2. Add the job with `pnpm cli exec '/cron add ... --session <sessionName> -- <prompt...>'` for actual Telegram delivery.
+1. Find the target session with `acpella exec /session list` if creating the job from local shell administration; if more than one candidate could match, confirm with the user before continuing.
+2. Add the job with `acpella exec '/cron add ... --session <sessionName> -- <prompt...>'` for actual Telegram delivery.
 3. Check it with `/cron show <id>` or `/cron list`.
 4. Use `/cron update <id> <minute> <hour> <day-of-month> <month> <day-of-week> ...` to change its schedule, destination, or prompt.
 5. Use `/cron disable <id>` when you want to pause it.
@@ -59,30 +59,30 @@ If `/cron add` is issued inside the Telegram conversation where the job should d
 
 `/cron update` always requires all five cron fields. Omitted `--session` and prompt values keep their existing values. Prompt updates must come after a literal `--` separator.
 
-When running `/cron update` through a shell with `pnpm cli exec`, quote the full slash command if the schedule contains `*`.
+When running `/cron update` through a shell with `acpella exec`, quote the full slash command if the schedule contains `*`.
 
 Update schedule:
 
 ```bash
-pnpm cli exec '/cron update morning-check 0 10 * * 1-5'
+acpella exec '/cron update morning-check 0 10 * * 1-5'
 ```
 
 Update destination while keeping the same schedule by repeating the current five cron fields:
 
 ```bash
-pnpm cli exec '/cron update morning-check 0 10 * * 1-5 --session tg-123456789'
+acpella exec '/cron update morning-check 0 10 * * 1-5 --session tg-123456789'
 ```
 
 Update prompt while keeping the same schedule by repeating the current five cron fields:
 
 ```bash
-pnpm cli exec '/cron update morning-check 0 10 * * 1-5 -- Check the project state and report anything urgent.'
+acpella exec '/cron update morning-check 0 10 * * 1-5 -- Check the project state and report anything urgent.'
 ```
 
 Update schedule, destination, and prompt together:
 
 ```bash
-pnpm cli exec '/cron update morning-check 0 10 * * 1-5 --session tg-123456789 -- Check the project state and report anything urgent.'
+acpella exec '/cron update morning-check 0 10 * * 1-5 --session tg-123456789 -- Check the project state and report anything urgent.'
 ```
 
 If updating `--session` from `/session list` output, ask the user to confirm when the intended destination is not obvious. To change a job id, delete the old job and add a new one.
@@ -97,7 +97,7 @@ Use these commands in the acpella process whose cron runner should be inspected 
 - `/cron start` to start that process's cron runner
 - `/cron stop` to stop that process's cron runner
 
-Cron job definition changes made through `pnpm cli exec '/cron add ...'`, `pnpm cli exec '/cron update ...'`, or direct edits to `.acpella/cron.json` write shared state. A live acpella process with an active cron runner reloads those file changes automatically.
+Cron job definition changes made through `acpella exec '/cron add ...'`, `acpella exec '/cron update ...'`, or direct edits to `.acpella/cron.json` write shared state. A live acpella process with an active cron runner reloads those file changes automatically.
 
 ## If cron is not behaving as expected
 

--- a/skills/acpella/references/customization.md
+++ b/skills/acpella/references/customization.md
@@ -21,7 +21,7 @@ Prompt changes apply to new sessions, not old ones. If you update `.acpella/AGEN
 /session new
 ```
 
-Run this in the target Telegram or REPL conversation. Do not use `pnpm cli exec` for `/session new`.
+Run this in the target Telegram or REPL conversation. Do not use `acpella exec` for `/session new`.
 
 ## Include lines
 

--- a/skills/acpella/references/sessions-and-agents.md
+++ b/skills/acpella/references/sessions-and-agents.md
@@ -12,7 +12,7 @@ In practice, session commands are for:
 - loading an older ACP session
 - closing a mapping you no longer want
 
-Run session lifecycle commands from Telegram or the REPL conversation whose context you mean to control. Do not use `pnpm cli exec` for `/session new`, `/session load`, or `/session close`. Use `pnpm cli exec /session list` and `pnpm cli exec '/session info <sessionName>'` only to discover existing session names and inspect known sessions for administrative commands such as cron creation.
+Run session lifecycle commands from Telegram or the REPL conversation whose context you mean to control. Do not use `acpella exec` for `/session new`, `/session load`, or `/session close`. Use `acpella exec /session list` and `acpella exec '/session info <sessionName>'` only to discover existing session names and inspect known sessions for administrative commands such as cron creation.
 
 ## Session commands
 
@@ -46,8 +46,8 @@ Use:
 Typical flow:
 
 ```bash
-pnpm cli exec /agent new codex npx -y @zed-industries/codex-acp
-pnpm cli exec /agent default codex
+acpella exec /agent new codex npx -y @zed-industries/codex-acp
+acpella exec /agent default codex
 ```
 
 That registers a real ACP agent and makes it the default for future sessions.
@@ -55,13 +55,13 @@ That registers a real ACP agent and makes it the default for future sessions.
 For Codex ACP, `npx -y @zed-industries/codex-acp` is the portable registration path. If `@zed-industries/codex-acp` is installed globally and `codex-acp` is available on the same `PATH` used by acpella, registering `codex-acp` directly is also fine:
 
 ```bash
-pnpm cli exec /agent new codex codex-acp
+acpella exec /agent new codex codex-acp
 ```
 
 Codex ACP reads Codex CLI configuration through its own `-c key=value` override flag. For example, to run Codex without sandboxing:
 
 ```bash
-pnpm cli exec /agent new codex npx -y @zed-industries/codex-acp -c sandbox_mode=danger-full-access
+acpella exec /agent new codex npx -y @zed-industries/codex-acp -c sandbox_mode=danger-full-access
 ```
 
 Check `codex-acp --help` for the current configuration override syntax before changing flags.

--- a/skills/acpella/references/systemd.md
+++ b/skills/acpella/references/systemd.md
@@ -4,13 +4,13 @@ Use this reference for installing acpella as a user service, updating the unit, 
 
 ## Generate the user unit
 
-From the acpella source checkout you want the service to run:
+Use the global `acpella` CLI linked to the checkout/version you want the service to run:
 
 ```bash
-pnpm cli exec /service systemd install
+acpella exec /service systemd install
 ```
 
-This writes a user unit for the current checkout. Prefer running this from a local shell through `exec`; it is a host administration side effect.
+This writes a user unit for the linked acpella installation. Prefer running this from a local shell through `exec`; it is a host administration side effect.
 
 ## First install
 

--- a/skills/acpella/references/troubleshooting.md
+++ b/skills/acpella/references/troubleshooting.md
@@ -36,18 +36,18 @@ If needed, reset with:
 /session new
 ```
 
-Run this in the target Telegram or REPL conversation. Do not use `pnpm cli exec` for `/session new`.
+Run this in the target Telegram or REPL conversation. Do not use `acpella exec` for `/session new`.
 
 For the general workflows behind those commands, continue with [sessions-and-agents.md](sessions-and-agents.md).
 
 For installation-wide checks from a local shell, prefer:
 
 ```bash
-pnpm cli exec /status
-pnpm cli exec /agent list
+acpella exec /status
+acpella exec /agent list
 ```
 
-Run these from the acpella source checkout that owns the running service, not from `ACPELLA_HOME` unless they are the same directory.
+Run these through the global `acpella` CLI linked to the checkout/version that owns the running service, not from `ACPELLA_HOME` unless they are the same directory.
 
 ## Prompt customization not taking effect
 
@@ -82,11 +82,11 @@ For the command workflow itself, continue with [cron.md](cron.md).
 For installation-wide cron checks from a local shell, prefer:
 
 ```bash
-pnpm cli exec /cron status
-pnpm cli exec /cron list
+acpella exec /cron status
+acpella exec /cron list
 ```
 
-Run these from the acpella source checkout that owns the running service, not from `ACPELLA_HOME` unless they are the same directory.
+Run these through the global `acpella` CLI linked to the checkout/version that owns the running service, not from `ACPELLA_HOME` unless they are the same directory.
 
 ## When deeper inspection is needed
 


### PR DESCRIPTION
- Closes https://github.com/hi-ogawa/acpella/issues/132

## Summary
- Point acpella operator guidance at the globally linked `acpella` CLI
- Update skill reference examples from `pnpm cli` to `acpella exec`
- Add README and skill references to `AGENTS.md` documentation guidance

## Verification
- `pnpm lint`