### PR TITLE
feat: add channel metadata to prompt

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -216,11 +216,6 @@ ${CLI_HELP}`);
     };
 
     try {
-      const conversationKind = ctx.message.message_thread_id
-        ? "topic"
-        : ctx.chat.type === "private"
-          ? "dm"
-          : "group";
       await handler.handle({
         sessionName,
         text: normalizeUserMention({
@@ -230,7 +225,7 @@ ${CLI_HELP}`);
         metadata: {
           promptMetadata: {
             timestamp: ctx.message.date * 1000,
-            conversation_kind: conversationKind,
+            conversation_kind: ctx.chat.type === "private" ? "direct" : "group",
           },
           cronDeliveryTarget: {
             telegram: {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,7 +15,7 @@ import {
   normalizeUserMention,
   TelegramChatActionManager,
 } from "./lib/telegram/utils.ts";
-import { addIndent, formatTime, sleep, truncateString } from "./lib/utils.ts";
+import { addIndent, sleep, truncateString } from "./lib/utils.ts";
 import { getVersion } from "./lib/version.ts";
 
 const CLI_HELP = `\
@@ -114,7 +114,7 @@ ${CLI_HELP}`);
 
   if (cli.command === "exec") {
     try {
-      await runExec({ config, handler, text: cli.args.join(" ") });
+      await runExec({ handler, text: cli.args.join(" ") });
     } finally {
       cronRunner.stop();
     }
@@ -229,9 +229,7 @@ ${CLI_HELP}`);
         }),
         metadata: {
           promptMetadata: {
-            sender_timestamp: formatTime(ctx.message.date * 1000, config.timezone),
-            timezone: config.timezone,
-            session_name: sessionName,
+            timestamp: ctx.message.date * 1000,
             conversation_kind: conversationKind,
           },
           cronDeliveryTarget: {
@@ -303,7 +301,7 @@ async function startRepl({
   async function sendMessage(text: string) {
     isHandling = true;
     try {
-      await runExec({ config, handler, text });
+      await runExec({ handler, text });
     } catch (error) {
       console.error(error);
     } finally {
@@ -349,23 +347,13 @@ async function startRepl({
 // make exitCode non-zero for soft errors (e.g. invalid command usages) on exec.
 // currently only hard errors can make exitCode = 1.
 // (plan: enhance context.send interface to include status semantics)
-async function runExec({
-  config,
-  handler,
-  text,
-}: {
-  config: AppConfig;
-  handler: Handler;
-  text: string;
-}) {
+async function runExec({ handler, text }: { handler: Handler; text: string }) {
   await handler.handle({
     sessionName: "repl",
     text,
     metadata: {
       promptMetadata: {
-        sender_timestamp: formatTime(Date.now(), config.timezone),
-        timezone: config.timezone,
-        session_name: "repl",
+        timestamp: Date.now(),
         conversation_kind: "repl",
       },
       cronDeliveryTarget: {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,6 +10,7 @@ import { createHandler, type Handler } from "./handler.ts";
 import { parseCli } from "./lib/cli.ts";
 import { markdownToTelegramHtml } from "./lib/telegram/format-html.ts";
 import {
+  formatTelegramConversationMetadata,
   formatTelegramSessionName,
   getTelegramRetryAfter,
   normalizeUserMention,
@@ -225,7 +226,7 @@ ${CLI_HELP}`);
         metadata: {
           promptMetadata: {
             timestamp: ctx.message.date * 1000,
-            conversation_kind: ctx.chat.type === "private" ? "direct" : "group",
+            channel: formatTelegramConversationMetadata(ctx),
           },
           cronDeliveryTarget: {
             telegram: {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,7 +15,7 @@ import {
   normalizeUserMention,
   TelegramChatActionManager,
 } from "./lib/telegram/utils.ts";
-import { addIndent, sleep, truncateString } from "./lib/utils.ts";
+import { addIndent, formatTime, sleep, truncateString } from "./lib/utils.ts";
 import { getVersion } from "./lib/version.ts";
 
 const CLI_HELP = `\
@@ -114,7 +114,7 @@ ${CLI_HELP}`);
 
   if (cli.command === "exec") {
     try {
-      await runExec({ handler, text: cli.args.join(" ") });
+      await runExec({ config, handler, text: cli.args.join(" ") });
     } finally {
       cronRunner.stop();
     }
@@ -216,6 +216,11 @@ ${CLI_HELP}`);
     };
 
     try {
+      const conversationKind = ctx.message.message_thread_id
+        ? "topic"
+        : ctx.chat.type === "private"
+          ? "dm"
+          : "group";
       await handler.handle({
         sessionName,
         text: normalizeUserMention({
@@ -223,7 +228,12 @@ ${CLI_HELP}`);
           username: botUsername,
         }),
         metadata: {
-          timestamp: ctx.message.date * 1000,
+          promptMetadata: {
+            sender_timestamp: formatTime(ctx.message.date * 1000, config.timezone),
+            timezone: config.timezone,
+            session_name: sessionName,
+            conversation_kind: conversationKind,
+          },
           cronDeliveryTarget: {
             telegram: {
               chatId,
@@ -293,7 +303,7 @@ async function startRepl({
   async function sendMessage(text: string) {
     isHandling = true;
     try {
-      await runExec({ handler, text });
+      await runExec({ config, handler, text });
     } catch (error) {
       console.error(error);
     } finally {
@@ -339,12 +349,25 @@ async function startRepl({
 // make exitCode non-zero for soft errors (e.g. invalid command usages) on exec.
 // currently only hard errors can make exitCode = 1.
 // (plan: enhance context.send interface to include status semantics)
-async function runExec({ handler, text }: { handler: Handler; text: string }) {
+async function runExec({
+  config,
+  handler,
+  text,
+}: {
+  config: AppConfig;
+  handler: Handler;
+  text: string;
+}) {
   await handler.handle({
     sessionName: "repl",
     text,
     metadata: {
-      timestamp: Date.now(),
+      promptMetadata: {
+        sender_timestamp: formatTime(Date.now(), config.timezone),
+        timezone: config.timezone,
+        session_name: "repl",
+        conversation_kind: "repl",
+      },
       cronDeliveryTarget: {
         repl: true,
       },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -354,7 +354,6 @@ async function runExec({ handler, text }: { handler: Handler; text: string }) {
     metadata: {
       promptMetadata: {
         timestamp: Date.now(),
-        conversation_kind: "repl",
       },
       cronDeliveryTarget: {
         repl: true,

--- a/src/handler.test.ts
+++ b/src/handler.test.ts
@@ -752,7 +752,12 @@ test("message metadata", async () => {
     sessionName: "test",
     text: `__keep_metadata: ok`,
     metadata: {
-      timestamp: Date.UTC(2024, 0, 2, 3, 4, 5),
+      promptMetadata: {
+        sender_timestamp: formatTime(Date.UTC(2024, 0, 2, 3, 4, 5), "Asia/Jakarta"),
+        timezone: "Asia/Jakarta",
+        session_name: "test",
+        conversation_kind: "repl",
+      },
     },
   });
   result = result
@@ -763,6 +768,7 @@ test("message metadata", async () => {
     sender_timestamp: <timestamp>
     timezone: <timezone>
     session_name: test
+    conversation_kind: repl
     </message_metadata>
     __keep_metadata: ok"
   `);

--- a/src/handler.test.ts
+++ b/src/handler.test.ts
@@ -773,7 +773,7 @@ test("message metadata", async () => {
     metadata: {
       promptMetadata: {
         timestamp: Date.UTC(2024, 0, 2, 3, 4, 5),
-        conversation_kind: "repl",
+        extraKey: "extraValue",
       },
     },
   });
@@ -785,7 +785,7 @@ test("message metadata", async () => {
     sender_timestamp: <timestamp>
     timezone: <timezone>
     session_name: test
-    conversation_kind: repl
+    extraKey: extraValue
     </message_metadata>
     __keep_metadata: ok"
   `);

--- a/src/handler.test.ts
+++ b/src/handler.test.ts
@@ -772,9 +772,7 @@ test("message metadata", async () => {
     text: `__keep_metadata: ok`,
     metadata: {
       promptMetadata: {
-        sender_timestamp: formatTime(Date.UTC(2024, 0, 2, 3, 4, 5), "Asia/Jakarta"),
-        timezone: "Asia/Jakarta",
-        session_name: "test",
+        timestamp: Date.UTC(2024, 0, 2, 3, 4, 5),
         conversation_kind: "repl",
       },
     },

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -14,6 +14,7 @@ import type { CronRunner, CronRunnerAgentOptions } from "./cron/runner.ts";
 import type { CronDeliveryTarget, CronJob, CronStore } from "./cron/store.ts";
 import { CommandHandler, type CommandTree } from "./lib/command.ts";
 import { formatSessionUpdateLogEntry, JsonLogger } from "./lib/logger.ts";
+import type { MessageMetadata } from "./lib/prompt.ts";
 import { buildFirstPrompt, buildMessageMetadataPrompt } from "./lib/prompt.ts";
 import { MESSAGE_SPLIT_BUDGET, ReplyManager } from "./lib/reply.ts";
 import { handleSystemdInstall } from "./lib/systemd.ts";
@@ -33,7 +34,7 @@ export interface HandlerContext {
   text: string;
   send: (text: string) => Promise<unknown>;
   metadata?: {
-    timestamp?: number;
+    promptMetadata?: MessageMetadata;
     cronDeliveryTarget?: CronDeliveryTarget;
   };
 }
@@ -73,12 +74,8 @@ export async function createHandler(
   async function handlePrompt(context: HandlerExtraContext): Promise<void> {
     let { reply, sessionName, metadata } = context;
     let promptText = "";
-    if (metadata?.timestamp) {
-      promptText = buildMessageMetadataPrompt({
-        timestamp: metadata.timestamp,
-        timezone: config.timezone,
-        sessionName,
-      });
+    if (metadata?.promptMetadata && Object.keys(metadata.promptMetadata).length > 0) {
+      promptText = buildMessageMetadataPrompt(metadata.promptMetadata);
     }
     promptText += context.text;
 

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -80,7 +80,10 @@ export async function createHandler(
     let { reply, sessionName, metadata } = context;
     let promptText = "";
     if (metadata?.promptMetadata && Object.keys(metadata.promptMetadata).length > 0) {
-      promptText = buildMessageMetadataPrompt(metadata.promptMetadata);
+      promptText = buildMessageMetadataPrompt(metadata.promptMetadata, {
+        timezone: config.timezone,
+        sessionName,
+      });
     }
     promptText += context.text;
 

--- a/src/lib/prompt.test.ts
+++ b/src/lib/prompt.test.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { expect, test } from "vitest";
 import { buildFirstPrompt, buildMessageMetadataPrompt } from "./prompt.ts";
+import { formatTime } from "./utils.ts";
 
 test("basic", () => {
   const output = buildFirstPrompt(path.resolve("./fixtures/prompt-includes/AGENTS.md"));
@@ -70,15 +71,17 @@ test("acpella skills directive", () => {
 
 test("message metadata", () => {
   const output = buildMessageMetadataPrompt({
-    timestamp: Date.UTC(2024, 0, 2, 3, 4, 5),
+    sender_timestamp: formatTime(Date.UTC(2024, 0, 2, 3, 4, 5), "Asia/Tokyo"),
     timezone: "Asia/Tokyo",
-    sessionName: "my-session",
+    session_name: "my-session",
+    conversation_kind: "dm",
   });
   expect(output).toMatchInlineSnapshot(`
     "<message_metadata>
     sender_timestamp: 2024-01-02T12:04:05+09:00
     timezone: Asia/Tokyo
     session_name: my-session
+    conversation_kind: dm
     </message_metadata>
     "
   `);

--- a/src/lib/prompt.test.ts
+++ b/src/lib/prompt.test.ts
@@ -1,7 +1,6 @@
 import path from "node:path";
 import { expect, test } from "vitest";
 import { buildFirstPrompt, buildMessageMetadataPrompt } from "./prompt.ts";
-import { formatTime } from "./utils.ts";
 
 test("basic", () => {
   const output = buildFirstPrompt(path.resolve("./fixtures/prompt-includes/AGENTS.md"));
@@ -70,12 +69,13 @@ test("acpella skills directive", () => {
 });
 
 test("message metadata", () => {
-  const output = buildMessageMetadataPrompt({
-    sender_timestamp: formatTime(Date.UTC(2024, 0, 2, 3, 4, 5), "Asia/Tokyo"),
-    timezone: "Asia/Tokyo",
-    session_name: "my-session",
-    conversation_kind: "dm",
-  });
+  const output = buildMessageMetadataPrompt(
+    {
+      timestamp: Date.UTC(2024, 0, 2, 3, 4, 5),
+      conversation_kind: "dm",
+    },
+    { timezone: "Asia/Tokyo", sessionName: "my-session" },
+  );
   expect(output).toMatchInlineSnapshot(`
     "<message_metadata>
     sender_timestamp: 2024-01-02T12:04:05+09:00

--- a/src/lib/prompt.test.ts
+++ b/src/lib/prompt.test.ts
@@ -72,7 +72,7 @@ test("message metadata", () => {
   const output = buildMessageMetadataPrompt(
     {
       timestamp: Date.UTC(2024, 0, 2, 3, 4, 5),
-      conversation_kind: "dm",
+      extraKey: "extraValue",
     },
     { timezone: "Asia/Tokyo", sessionName: "my-session" },
   );
@@ -81,7 +81,7 @@ test("message metadata", () => {
     sender_timestamp: 2024-01-02T12:04:05+09:00
     timezone: Asia/Tokyo
     session_name: my-session
-    conversation_kind: dm
+    extraKey: extraValue
     </message_metadata>
     "
   `);

--- a/src/lib/prompt.ts
+++ b/src/lib/prompt.ts
@@ -20,13 +20,11 @@ ${customPrompt.trim()}
   return output;
 }
 
-export type MessageMetadataValue = string | number | boolean;
-
-export type MessageMetadata = Record<string, MessageMetadataValue>;
+export type MessageMetadata = Record<string, unknown>;
 
 export function buildMessageMetadataPrompt(metadata: MessageMetadata): string {
   const lines = Object.entries(metadata)
-    .map(([key, value]) => `${key}: ${value}`)
+    .map(([key, value]) => `${key}: ${String(value)}`)
     .join("\n");
   return `\
 <message_metadata>

--- a/src/lib/prompt.ts
+++ b/src/lib/prompt.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import { addIndent } from "./utils.ts";
+import { addIndent, formatTime } from "./utils.ts";
 
 const INCLUDE_LINE_RE = /^[^\S\r\n]*@(\S+)[^\S\r\n]*$/gm;
 const ACP_DIRECTIVE_LINE_RE = /^[^\S\r\n]*::acpella\s+(\S+)(?:\s+(.+?))?[^\S\r\n]*$/gm;
@@ -20,11 +20,26 @@ ${customPrompt.trim()}
   return output;
 }
 
-export type MessageMetadata = Record<string, unknown>;
+export interface MessageMetadata {
+  timestamp: number;
+  [key: string]: unknown;
+}
 
-export function buildMessageMetadataPrompt(metadata: MessageMetadata): string {
-  const lines = Object.entries(metadata)
+export function buildMessageMetadataPrompt(
+  metadata: MessageMetadata,
+  context: { timezone: string; sessionName: string },
+): string {
+  const extraLines = Object.entries(metadata)
+    .filter(([key]) => key !== "timestamp")
     .map(([key, value]) => `${key}: ${String(value)}`)
+    .join("\n");
+  const lines = [
+    `sender_timestamp: ${formatTime(metadata.timestamp, context.timezone)}`,
+    `timezone: ${context.timezone}`,
+    `session_name: ${context.sessionName}`,
+    extraLines,
+  ]
+    .filter(Boolean)
     .join("\n");
   return `\
 <message_metadata>

--- a/src/lib/prompt.ts
+++ b/src/lib/prompt.ts
@@ -29,21 +29,16 @@ export function buildMessageMetadataPrompt(
   metadata: MessageMetadata,
   context: { timezone: string; sessionName: string },
 ): string {
-  const extraLines = Object.entries(metadata)
-    .filter(([key]) => key !== "timestamp")
+  const { timestamp, ...rest } = metadata;
+  const extra = Object.entries(rest)
     .map(([key, value]) => `${key}: ${String(value)}`)
-    .join("\n");
-  const lines = [
-    `sender_timestamp: ${formatTime(metadata.timestamp, context.timezone)}`,
-    `timezone: ${context.timezone}`,
-    `session_name: ${context.sessionName}`,
-    extraLines,
-  ]
-    .filter(Boolean)
     .join("\n");
   return `\
 <message_metadata>
-${lines}
+sender_timestamp: ${formatTime(timestamp, context.timezone)}
+timezone: ${context.timezone}
+session_name: ${context.sessionName}
+${extra}
 </message_metadata>
 `;
 }

--- a/src/lib/prompt.ts
+++ b/src/lib/prompt.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import { addIndent, formatTime } from "./utils.ts";
+import { addIndent } from "./utils.ts";
 
 const INCLUDE_LINE_RE = /^[^\S\r\n]*@(\S+)[^\S\r\n]*$/gm;
 const ACP_DIRECTIVE_LINE_RE = /^[^\S\r\n]*::acpella\s+(\S+)(?:\s+(.+?))?[^\S\r\n]*$/gm;
@@ -20,19 +20,17 @@ ${customPrompt.trim()}
   return output;
 }
 
-interface MessageMetadata {
-  timestamp: number;
-  timezone: string;
-  sessionName: string;
-}
+export type MessageMetadataValue = string | number | boolean;
+
+export type MessageMetadata = Record<string, MessageMetadataValue>;
 
 export function buildMessageMetadataPrompt(metadata: MessageMetadata): string {
-  const timestamp = formatTime(metadata.timestamp, metadata.timezone);
+  const lines = Object.entries(metadata)
+    .map(([key, value]) => `${key}: ${value}`)
+    .join("\n");
   return `\
 <message_metadata>
-sender_timestamp: ${timestamp}
-timezone: ${metadata.timezone}
-session_name: ${metadata.sessionName}
+${lines}
 </message_metadata>
 `;
 }

--- a/src/lib/prompt.ts
+++ b/src/lib/prompt.ts
@@ -31,7 +31,7 @@ export function buildMessageMetadataPrompt(
 ): string {
   const { timestamp, ...rest } = metadata;
   const extra = Object.entries(rest)
-    .map(([key, value]) => `${key}: ${String(value)}`)
+    .map((kv) => kv.join(": "))
     .join("\n");
   return `\
 <message_metadata>

--- a/src/lib/telegram/utils.ts
+++ b/src/lib/telegram/utils.ts
@@ -35,6 +35,21 @@ export function parseTelegramSessionName(sessionName: string) {
   return { chatId, messageThreadId };
 }
 
+export function formatTelegramConversationMetadata(context: Context): string {
+  const chat = context.chat;
+  if (!chat) {
+    return "telegram:unknown";
+  }
+  if (chat.type === "private") {
+    return "telegram:direct";
+  }
+  const messageThreadId = context.message?.message_thread_id;
+  if (messageThreadId !== undefined) {
+    return `telegram:group:${chat.title}:topic:${messageThreadId}`;
+  }
+  return `telegram:group:${chat.title}`;
+}
+
 export function getTelegramRetryAfter(error: unknown): number | undefined {
   if (error instanceof GrammyError && error.error_code === 429) {
     return error.parameters.retry_after;


### PR DESCRIPTION
## Summary
- build prompt metadata at ingress instead of hardcoding fields in the handler
- render the message metadata block from a flat metadata map passed through to prompt.ts
- add conversation_kind for Telegram and REPL contexts while keeping session_name in prompt metadata

## Testing
- not run (per request)