### PR TITLE
feat(cron): support suppressing response via `NO_REPLY`

### DIFF
--- a/skills/acpella/references/cron.md
+++ b/skills/acpella/references/cron.md
@@ -6,8 +6,6 @@ Use this reference for scheduled prompts in acpella.
 
 Cron lets acpella send a prompt to a target conversation on a schedule. This is useful for recurring reminders, recurring checks, or automated prompts tied to a specific chat or thread.
 
-If a cron agent response is exactly `NO_REPLY` after trimming whitespace, acpella treats the run as successful and suppresses outbound delivery. This convention is cron-only; interactive replies still deliver ordinary `NO_REPLY` text.
-
 ## Main commands
 
 Use:

--- a/skills/acpella/references/cron.md
+++ b/skills/acpella/references/cron.md
@@ -6,6 +6,8 @@ Use this reference for scheduled prompts in acpella.
 
 Cron lets acpella send a prompt to a target conversation on a schedule. This is useful for recurring reminders, recurring checks, or automated prompts tied to a specific chat or thread.
 
+If a cron agent response is exactly `NO_REPLY` after trimming whitespace, acpella treats the run as successful and suppresses outbound delivery. This convention is cron-only; interactive replies still deliver ordinary `NO_REPLY` text.
+
 ## Main commands
 
 Use:

--- a/skills/acpella/references/cron.md
+++ b/skills/acpella/references/cron.md
@@ -6,7 +6,7 @@ Use this reference for scheduled prompts in acpella.
 
 Cron lets acpella send a prompt to a target conversation on a schedule. This is useful for recurring reminders, recurring checks, or automated prompts tied to a specific chat or thread.
 
-If a cron agent response is exactly `NO_REPLY` after trimming whitespace, acpella treats the run as successful and suppresses outbound delivery. This convention is cron-only; interactive replies still deliver ordinary `NO_REPLY` text.
+If a cron agent response is exactly `NO_REPLY` after trimming whitespace, acpella treats the run as successful and suppresses outbound delivery. Use this for scheduled checks that should stay silent when there is nothing actionable to report, while still allowing failures to surface through cron error delivery. This convention is cron-only; interactive replies still deliver ordinary `NO_REPLY` text.
 
 ## Main commands
 

--- a/src/cron/runner.ts
+++ b/src/cron/runner.ts
@@ -93,13 +93,9 @@ export class CronRunner {
       });
       if (response.trim() === "NO_REPLY") {
         console.log(`[cron] Suppressed delivery for cron '${job.id}': NO_REPLY`);
-        store.updateRun(run.id, {
-          finishedAt: formatTime(Date.now()),
-          status: "succeeded",
-        });
-        return;
+      } else {
+        await this.options.delivery.send({ target: job.target.delivery, text: response });
       }
-      await this.options.delivery.send({ target: job.target.delivery, text: response });
       store.updateRun(run.id, {
         finishedAt: formatTime(Date.now()),
         status: "succeeded",

--- a/src/cron/runner.ts
+++ b/src/cron/runner.ts
@@ -91,6 +91,14 @@ export class CronRunner {
         sessionName: job.target.sessionName,
         text: prompt,
       });
+      if (response.trim() === "NO_REPLY") {
+        console.log(`[cron] Suppressed delivery for cron '${job.id}': NO_REPLY`);
+        store.updateRun(run.id, {
+          finishedAt: formatTime(Date.now()),
+          status: "succeeded",
+        });
+        return;
+      }
       await this.options.delivery.send({ target: job.target.delivery, text: response });
       store.updateRun(run.id, {
         finishedAt: formatTime(Date.now()),

--- a/src/cron/runner.ts
+++ b/src/cron/runner.ts
@@ -91,14 +91,6 @@ export class CronRunner {
         sessionName: job.target.sessionName,
         text: prompt,
       });
-      if (response.trim() === "NO_REPLY") {
-        console.log(`[cron] Suppressed delivery for cron '${job.id}': NO_REPLY`);
-        store.updateRun(run.id, {
-          finishedAt: formatTime(Date.now()),
-          status: "succeeded",
-        });
-        return;
-      }
       await this.options.delivery.send({ target: job.target.delivery, text: response });
       store.updateRun(run.id, {
         finishedAt: formatTime(Date.now()),

--- a/src/handler.test.ts
+++ b/src/handler.test.ts
@@ -1308,6 +1308,52 @@ test("cron error delivery", async ({ onTestFinished }) => {
   `);
 });
 
+test("cron suppresses NO_REPLY delivery", async ({ onTestFinished }) => {
+  // Timeline:
+  // - 07:00: add test-job for every minute with a raw NO_REPLY response.
+  // - 07:01: test-job fires, run succeeds, and delivery is suppressed.
+  vi.useFakeTimers({
+    now: Date.parse("2026-04-18T07:00:00+07:00"),
+  });
+  onTestFinished(() => {
+    vi.useRealTimers();
+  });
+
+  const tester = await createHandlerTester();
+  tester.cronRunner.start();
+  onTestFinished(() => {
+    tester.cronRunner.stop();
+  });
+
+  const session = tester.createSession("test", {
+    metadata: { cronDeliveryTarget: { repl: true } },
+  });
+  expect(await session.request("/cron add test-job * * * * * -- __raw:NO_REPLY"))
+    .toMatchInlineSnapshot(`
+    "[⚙️ System]
+    Added cron job: test-job"
+  `);
+
+  vi.advanceTimersByTime(60 * 1000);
+  await vi.waitUntil(async () => {
+    const output = await session.request("/cron show test-job");
+    return output.includes("last: succeeded");
+  });
+  expect(await session.request("/cron show test-job")).toMatchInlineSnapshot(`
+    "[⚙️ System]
+    id: test-job
+    enabled: yes
+    schedule: * * * * *
+    timezone: Asia/Jakarta
+    target session: test
+    delivery target: repl
+    next: 2026-04-18T07:02:00+07:00
+    last: succeeded, scheduled 2026-04-18T00:01:00Z, finished 2026-04-18T00:01:00Z
+    prompt: __raw:NO_REPLY"
+  `);
+  expect(tester.cronDeliveries).toMatchInlineSnapshot(`[]`);
+});
+
 test("cron with session name", async ({ onTestFinished }) => {
   // Sequence:
   // - Create tg-12345 and tg-12345-678 sessions so --session can target known sessions.

--- a/src/lib/test-agent.ts
+++ b/src/lib/test-agent.ts
@@ -179,7 +179,11 @@ class EchoAgent implements Agent {
     }
 
     let reportText: string;
-    if (text.startsWith("__env:")) {
+    const rawMarker = "__raw:";
+    const rawMarkerIndex = text.indexOf(rawMarker);
+    if (rawMarkerIndex >= 0) {
+      reportText = text.slice(rawMarkerIndex + rawMarker.length).trim();
+    } else if (text.startsWith("__env:")) {
       const key = text.slice(6);
       const value = process.env[key] ?? "(unset)";
       reportText = `env: ${key}=${value}`;


### PR DESCRIPTION
## Summary
- suppress outbound cron delivery when the trimmed agent response is exactly `NO_REPLY`
- log cron delivery suppression for service-log debugging
- document the cron-only `NO_REPLY` convention

## Tests
- Not run per request

Fixes #142