### PR TITLE
docs: document systemd linger gotchas

### DIFF
--- a/skills/acpella/references/systemd.md
+++ b/skills/acpella/references/systemd.md
@@ -50,9 +50,7 @@ One blunt systemd-level option is masking sleep targets:
 sudo systemctl mask sleep.target suspend.target hibernate.target hybrid-sleep.target
 ```
 
-Another option is configuring lid behavior in `/etc/systemd/logind.conf`, such
-as `HandleLidSwitch=ignore`, then restarting `systemd-logind`. Treat these as
-host power-policy choices, not acpella configuration.
+Treat this as a host power-policy choice, not acpella configuration.
 
 ## After updating the unit
 

--- a/skills/acpella/references/systemd.md
+++ b/skills/acpella/references/systemd.md
@@ -19,6 +19,26 @@ systemctl --user daemon-reload
 systemctl --user enable --now acpella
 ```
 
+## Boot and suspend gotchas
+
+`acpella` is installed as a systemd user service. If it should start after boot
+without an interactive login, enable lingering for that user:
+
+```bash
+sudo loginctl enable-linger $USER
+loginctl show-user $USER -p Linger
+```
+
+Lingering starts the user's `systemd --user` manager at boot, so enabled user
+services can run before GDM, GNOME, or another graphical login session exists.
+That is useful for headless recovery after reboot, but it can also start user
+services earlier than expected. Keep the unit headless and avoid assumptions
+about `DISPLAY`, Wayland, desktop session targets, or an unlocked keyring.
+
+Lingering does not prevent suspend. For an always-on laptop or closed-lid bot,
+also configure the machine not to sleep; otherwise all services stop while the
+machine is suspended.
+
 ## After updating the unit
 
 ```bash

--- a/skills/acpella/references/systemd.md
+++ b/skills/acpella/references/systemd.md
@@ -36,8 +36,23 @@ services earlier than expected. Keep the unit headless and avoid assumptions
 about `DISPLAY`, Wayland, desktop session targets, or an unlocked keyring.
 
 Lingering does not prevent suspend. For an always-on laptop or closed-lid bot,
-also configure the machine not to sleep; otherwise all services stop while the
-machine is suspended.
+also configure the host not to sleep; otherwise all services stop while the
+machine is suspended. Common checks:
+
+```bash
+systemctl status sleep.target suspend.target hibernate.target hybrid-sleep.target
+systemd-inhibit --list
+```
+
+One blunt systemd-level option is masking sleep targets:
+
+```bash
+sudo systemctl mask sleep.target suspend.target hibernate.target hybrid-sleep.target
+```
+
+Another option is configuring lid behavior in `/etc/systemd/logind.conf`, such
+as `HandleLidSwitch=ignore`, then restarting `systemd-logind`. Treat these as
+host power-policy choices, not acpella configuration.
 
 ## After updating the unit
 

--- a/skills/acpella/references/systemd.md
+++ b/skills/acpella/references/systemd.md
@@ -44,7 +44,8 @@ systemctl status sleep.target suspend.target hibernate.target hybrid-sleep.targe
 systemd-inhibit --list
 ```
 
-One blunt systemd-level option is masking sleep targets:
+For an always-on host, disable system sleep. One systemd-level option is masking
+sleep targets:
 
 ```bash
 sudo systemctl mask sleep.target suspend.target hibernate.target hybrid-sleep.target


### PR DESCRIPTION
## Summary
- Document when `loginctl enable-linger` is needed for acpella's systemd user service.
- Clarify that linger can start user services before the graphical session and does not prevent suspend.

## Testing
- Not run; docs-only change.