### PR TITLE
refactor: structure command usage metadata

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -220,7 +220,8 @@ export async function createHandler(
   const systemSessionCommands: SystemCommandTree[string] = [
     {
       tokens: ["info"],
-      help: "/session info [sessionName] - Show info about a session.",
+      usage: "/session info [sessionName]",
+      description: "Show info about a session.",
       withArgs: true,
       run: async ({ args, reply, ...context }) => {
         let arg = args[0];
@@ -253,7 +254,8 @@ renew: ${renderSessionRenewPolicy({ policy: stateSession.renew, timezone: config
     },
     {
       tokens: ["list"],
-      help: "/session list [--all] - List known agent sessions.",
+      usage: "/session list [--all]",
+      description: "List known agent sessions.",
       withArgs: true,
       run: async ({ reply, args }) => {
         const state = stateStore.get();
@@ -314,7 +316,8 @@ Unmapped acp sessions:
     },
     {
       tokens: ["new"],
-      help: "/session new [agent] - Start a new agent session.",
+      usage: "/session new [agent]",
+      description: "Start a new agent session.",
       withArgs: true,
       run: async (context) => {
         const { args, reply, sessionName } = context;
@@ -332,7 +335,8 @@ Unmapped acp sessions:
     },
     {
       tokens: ["load"],
-      help: "/session load <sessionId|agent:sessionId> - Load an existing agent session.",
+      usage: "/session load <sessionId|agent:sessionId>",
+      description: "Load an existing agent session.",
       withArgs: true,
       run: async ({ args, reply, sessionName }) => {
         const sessionIdArg = args[0];
@@ -362,7 +366,8 @@ Unmapped acp sessions:
     },
     {
       tokens: ["close"],
-      help: "/session close [sessionId|agent:sessionId] - Close an agent session.",
+      usage: "/session close [sessionId|agent:sessionId]",
+      description: "Close an agent session.",
       withArgs: true,
       run: async ({ args, reply, sessionName }) => {
         const stateSession = stateStore.getSession(sessionName);
@@ -389,7 +394,8 @@ Unmapped acp sessions:
     },
     {
       tokens: ["verbose"],
-      help: "/session verbose <off|tool|thinking|all> [sessionName] - Set internal progress output.",
+      usage: "/session verbose <off|tool|thinking|all> [sessionName]",
+      description: "Set internal progress output.",
       withArgs: true,
       run: async ({ args, reply, sessionName }) => {
         const [value, targetSession = sessionName] = args;
@@ -400,7 +406,8 @@ Unmapped acp sessions:
     },
     {
       tokens: ["renew"],
-      help: "/session renew <off|daily|daily:N> [sessionName] - Set session renewal policy.",
+      usage: "/session renew <off|daily|daily:N> [sessionName]",
+      description: "Set session renewal policy.",
       withArgs: true,
       run: async ({ args, reply, sessionName }) => {
         const [value, targetSession] = args;
@@ -427,7 +434,8 @@ Unmapped acp sessions:
   const systemAgentCommands: SystemCommandTree[string] = [
     {
       tokens: ["list"],
-      help: "/agent list - List configured agents.",
+      usage: "/agent list",
+      description: "List configured agents.",
       run: async ({ reply }) => {
         const state = stateStore.get();
         let response = "";
@@ -440,7 +448,8 @@ Unmapped acp sessions:
     },
     {
       tokens: ["new"],
-      help: "/agent new <name> <command...> - Save a new agent.",
+      usage: "/agent new <name> <command...>",
+      description: "Save a new agent.",
       withArgs: true,
       run: async ({ args, reply }) => {
         const [name, ...commandParts] = args;
@@ -457,7 +466,8 @@ Unmapped acp sessions:
     },
     {
       tokens: ["remove"],
-      help: "/agent remove <name> - Remove an agent.",
+      usage: "/agent remove <name>",
+      description: "Remove an agent.",
       withArgs: true,
       run: async ({ args, reply }) => {
         const name = args[0];
@@ -492,7 +502,8 @@ ${referencedSessions.length} session(s) still reference it.
     },
     {
       tokens: ["default"],
-      help: "/agent default [name] - Show or set the default agent.",
+      usage: "/agent default [name]",
+      description: "Show or set the default agent.",
       withArgs: true,
       run: async ({ args, reply }) => {
         const name = args[0];
@@ -517,7 +528,8 @@ ${referencedSessions.length} session(s) still reference it.
   const systemCronCommands: SystemCommandTree[string] = [
     {
       tokens: ["status"],
-      help: "/cron status - Show cron scheduler status.",
+      usage: "/cron status",
+      description: "Show cron scheduler status.",
       run: async ({ reply }) => {
         const cronRunner = getCronRunner();
         const jobs = cronStore.listJobs();
@@ -531,7 +543,8 @@ enabled jobs: ${enabledJobs.length}
     },
     {
       tokens: ["start"],
-      help: "/cron start - Start cron scheduler.",
+      usage: "/cron start",
+      description: "Start cron scheduler.",
       run: async ({ reply }) => {
         const cronRunner = getCronRunner();
         if (!cronRunner) {
@@ -544,7 +557,8 @@ enabled jobs: ${enabledJobs.length}
     },
     {
       tokens: ["stop"],
-      help: "/cron stop - Stop cron scheduler.",
+      usage: "/cron stop",
+      description: "Stop cron scheduler.",
       run: async ({ reply }) => {
         const cronRunner = getCronRunner();
         if (!cronRunner) {
@@ -557,7 +571,8 @@ enabled jobs: ${enabledJobs.length}
     },
     {
       tokens: ["add"],
-      help: `${CRON_ADD_USAGE} - Add a cron job.`,
+      usage: CRON_ADD_USAGE,
+      description: "Add a cron job.",
       withArgs: true,
       run: async ({ args, reply, sessionName, metadata }) => {
         const cron = parseCronArgs(args, config.timezone);
@@ -604,7 +619,8 @@ enabled jobs: ${enabledJobs.length}
     },
     {
       tokens: ["update"],
-      help: `${CRON_UPDATE_USAGE} - Update a cron job.`,
+      usage: CRON_UPDATE_USAGE,
+      description: "Update a cron job.",
       withArgs: true,
       run: async ({ args, reply }) => {
         const cron = parseCronArgs(args, config.timezone);
@@ -647,14 +663,16 @@ enabled jobs: ${enabledJobs.length}
     },
     {
       tokens: ["list"],
-      help: "/cron list - List cron jobs.",
+      usage: "/cron list",
+      description: "List cron jobs.",
       run: async ({ reply }) => {
         await reply.system(renderCronList(cronStore));
       },
     },
     {
       tokens: ["show"],
-      help: "/cron show <id> - Show a cron job.",
+      usage: "/cron show <id>",
+      description: "Show a cron job.",
       withArgs: true,
       run: async ({ args, reply }) => {
         const parsed = parseCronIdArg(args, "Usage: /cron show <id>");
@@ -673,7 +691,8 @@ enabled jobs: ${enabledJobs.length}
     },
     {
       tokens: ["enable"],
-      help: "/cron enable <id> - Enable a cron job.",
+      usage: "/cron enable <id>",
+      description: "Enable a cron job.",
       withArgs: true,
       run: async ({ args, reply }) => {
         const parsed = parseCronIdArg(args, "Usage: /cron enable <id>");
@@ -697,7 +716,8 @@ enabled jobs: ${enabledJobs.length}
     },
     {
       tokens: ["disable"],
-      help: "/cron disable <id> - Disable a cron job.",
+      usage: "/cron disable <id>",
+      description: "Disable a cron job.",
       withArgs: true,
       run: async ({ args, reply }) => {
         const parsed = parseCronIdArg(args, "Usage: /cron disable <id>");
@@ -721,7 +741,8 @@ enabled jobs: ${enabledJobs.length}
     },
     {
       tokens: ["delete"],
-      help: "/cron delete <id> - Delete a cron job.",
+      usage: "/cron delete <id>",
+      description: "Delete a cron job.",
       withArgs: true,
       run: async ({ args, reply }) => {
         const parsed = parseCronIdArg(args, "Usage: /cron delete <id>");
@@ -749,7 +770,8 @@ enabled jobs: ${enabledJobs.length}
     status: [
       {
         tokens: [],
-        help: "/status - Show service status.",
+        usage: "/status",
+        description: "Show service status.",
         run: async ({ reply, sessionName }) => {
           const inFlightSessions = [...activeSessions.entries()]
             .map(([sessionName, session]) => {
@@ -775,7 +797,8 @@ ${inFlightSessions ? `in-flight sessions:\n${inFlightSessions}` : ""}
     service: [
       {
         tokens: ["systemd", "install"],
-        help: "/service systemd install - Install systemd service.",
+        usage: "/service systemd install",
+        description: "Install systemd service.",
         run: async ({ reply }) => {
           const message = handleSystemdInstall();
           await reply.system(message);
@@ -783,7 +806,8 @@ ${inFlightSessions ? `in-flight sessions:\n${inFlightSessions}` : ""}
       },
       {
         tokens: ["exit"],
-        help: "/service exit - Exit acpella.",
+        usage: "/service exit",
+        description: "Exit acpella.",
         run: async ({ reply }) => {
           await reply.system("Exiting acpella.");
           handler.stop();
@@ -794,7 +818,8 @@ ${inFlightSessions ? `in-flight sessions:\n${inFlightSessions}` : ""}
     cancel: [
       {
         tokens: [],
-        help: "/cancel - Cancel the active agent turn.",
+        usage: "/cancel",
+        description: "Cancel the active agent turn.",
         run: async ({ reply, sessionName }) => {
           const session = activeSessions.get(sessionName);
           if (!session) {

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -5,8 +5,6 @@ import { AgentManager } from "./lib/acp/index.ts";
 import type { AgentSessionProcess } from "./lib/acp/index.ts";
 import { CommandHandler, type CommandTree } from "./lib/command.ts";
 import {
-  CRON_ADD_USAGE,
-  CRON_UPDATE_USAGE,
   parseCronArgs,
   parseCronIdArg,
   renderCronList,
@@ -570,7 +568,8 @@ enabled jobs: ${enabledJobs.length}
     },
     {
       tokens: ["add"],
-      usage: CRON_ADD_USAGE,
+      usage:
+        "/cron add <id> <minute> <hour> <day-of-month> <month> <day-of-week> [--session <sessionName>] -- <prompt...>",
       description: "Add a cron job.",
       withArgs: true,
       run: async ({ args, reply, sessionName, metadata }) => {
@@ -618,7 +617,8 @@ enabled jobs: ${enabledJobs.length}
     },
     {
       tokens: ["update"],
-      usage: CRON_UPDATE_USAGE,
+      usage:
+        "/cron update <id> <minute> <hour> <day-of-month> <month> <day-of-week> [--session <sessionName>] [-- <prompt...>]",
       description: "Update a cron job.",
       withArgs: true,
       run: async ({ args, reply }) => {

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -338,10 +338,10 @@ Unmapped acp sessions:
       usage: "/session load <sessionId|agent:sessionId>",
       description: "Load an existing agent session.",
       withArgs: true,
-      run: async ({ args, reply, sessionName }) => {
+      run: async ({ args, reply, sessionName, usage }) => {
         const sessionIdArg = args[0];
         if (!sessionIdArg) {
-          await reply.system("Usage: /session load <sessionId|agent:sessionId>");
+          await reply.system(usage);
           return;
         }
         const stateSession = stateStore.getSession(sessionName);
@@ -409,9 +409,8 @@ Unmapped acp sessions:
       usage: "/session renew <off|daily|daily:N> [sessionName]",
       description: "Set session renewal policy.",
       withArgs: true,
-      run: async ({ args, reply, sessionName }) => {
+      run: async ({ args, reply, sessionName, usage }) => {
         const [value, targetSession] = args;
-        const usage = "Usage: /session renew <off|daily|daily:N> [sessionName]";
         if (!value) {
           await reply.system(usage);
           return;
@@ -451,11 +450,11 @@ Unmapped acp sessions:
       usage: "/agent new <name> <command...>",
       description: "Save a new agent.",
       withArgs: true,
-      run: async ({ args, reply }) => {
+      run: async ({ args, reply, usage }) => {
         const [name, ...commandParts] = args;
         const command = commandParts.join(" ");
         if (!name || !command) {
-          await reply.system("Usage: /agent new <name> <command...>");
+          await reply.system(usage);
           return;
         }
         stateStore.set((state) => {
@@ -469,11 +468,11 @@ Unmapped acp sessions:
       usage: "/agent remove <name>",
       description: "Remove an agent.",
       withArgs: true,
-      run: async ({ args, reply }) => {
+      run: async ({ args, reply, usage }) => {
         const name = args[0];
         const state = stateStore.get();
         if (!name) {
-          await reply.system("Usage: /agent remove <name>");
+          await reply.system(usage);
           return;
         }
         if (!state.agents[name]) {
@@ -674,8 +673,8 @@ enabled jobs: ${enabledJobs.length}
       usage: "/cron show <id>",
       description: "Show a cron job.",
       withArgs: true,
-      run: async ({ args, reply }) => {
-        const parsed = parseCronIdArg(args, "Usage: /cron show <id>");
+      run: async ({ args, reply, usage }) => {
+        const parsed = parseCronIdArg(args, usage);
         if (!parsed.ok) {
           await reply.system(parsed.value);
           return;
@@ -694,8 +693,8 @@ enabled jobs: ${enabledJobs.length}
       usage: "/cron enable <id>",
       description: "Enable a cron job.",
       withArgs: true,
-      run: async ({ args, reply }) => {
-        const parsed = parseCronIdArg(args, "Usage: /cron enable <id>");
+      run: async ({ args, reply, usage }) => {
+        const parsed = parseCronIdArg(args, usage);
         if (!parsed.ok) {
           await reply.system(parsed.value);
           return;
@@ -719,8 +718,8 @@ enabled jobs: ${enabledJobs.length}
       usage: "/cron disable <id>",
       description: "Disable a cron job.",
       withArgs: true,
-      run: async ({ args, reply }) => {
-        const parsed = parseCronIdArg(args, "Usage: /cron disable <id>");
+      run: async ({ args, reply, usage }) => {
+        const parsed = parseCronIdArg(args, usage);
         if (!parsed.ok) {
           await reply.system(parsed.value);
           return;
@@ -744,8 +743,8 @@ enabled jobs: ${enabledJobs.length}
       usage: "/cron delete <id>",
       description: "Delete a cron job.",
       withArgs: true,
-      run: async ({ args, reply }) => {
-        const parsed = parseCronIdArg(args, "Usage: /cron delete <id>");
+      run: async ({ args, reply, usage }) => {
+        const parsed = parseCronIdArg(args, usage);
         if (!parsed.ok) {
           await reply.system(parsed.value);
           return;

--- a/src/lib/command.test.ts
+++ b/src/lib/command.test.ts
@@ -12,7 +12,8 @@ describe(CommandHandler, () => {
       ping: [
         {
           tokens: [],
-          help: "/ping - Ping the service.",
+          usage: "/ping",
+          description: "Ping the service.",
           run: async ({ prefix }) => {
             events.push(`${prefix}:pong`);
           },
@@ -21,17 +22,30 @@ describe(CommandHandler, () => {
       config: [
         {
           tokens: ["show"],
-          help: "/config show - Show config.",
+          usage: "/config show",
+          description: "Show config.",
           run: async ({ prefix }) => {
             events.push(`${prefix}:config`);
           },
         },
         {
           tokens: ["set"],
-          help: "/config set <value...> - Set config.",
+          usage: "/config set <value...>",
+          description: "Set config.",
           withArgs: true,
           run: async ({ args, prefix }) => {
             events.push(`${prefix}:set:${args.join(" ")}`);
+          },
+        },
+      ],
+      test: [
+        {
+          tokens: [],
+          usage: "/test <value...>",
+          description: "Run test command.",
+          withArgs: true,
+          run: async ({ usage }) => {
+            events.push(usage);
           },
         },
       ],
@@ -56,6 +70,7 @@ describe(CommandHandler, () => {
     expect(await commandHandler.handle({ text: "/config help", context })).toBe(true);
     expect(await commandHandler.handle({ text: "/config missing", context })).toBe(true);
     expect(await commandHandler.handle({ text: "/config set theme dark", context })).toBe(true);
+    expect(await commandHandler.handle({ text: "/test hello", context })).toBe(true);
     expect(await commandHandler.handle({ text: "/help", context })).toBe(true);
 
     expect(events).toMatchInlineSnapshot(`
@@ -74,6 +89,7 @@ describe(CommandHandler, () => {
         /config set <value...> - Set config.
       ",
         "test:set:theme dark",
+        "Usage: /test <value...>",
         "Commands:
       /help - Show command help.
 
@@ -83,6 +99,9 @@ describe(CommandHandler, () => {
       /config
         /config show - Show config.
         /config set <value...> - Set config.
+
+      /test
+        /test <value...> - Run test command.
 
       ",
       ]

--- a/src/lib/command.ts
+++ b/src/lib/command.ts
@@ -2,13 +2,15 @@ export type CommandTree<T> = Record<string, CommandSpec<T>[]>;
 
 type CommandSpec<T> = {
   tokens: string[];
-  help: string;
+  usage: string;
+  description: string;
   withArgs?: boolean;
   run: (context: CommandRunContext<T>) => Promise<void>;
 };
 
 type CommandRunContext<T> = T & {
   args: string[];
+  usage: string;
 };
 
 interface CommandHandlerOptions<T> {
@@ -50,6 +52,7 @@ export class CommandHandler<T> {
     await matched.command.run({
       ...context,
       args: matched.args,
+      usage: `Usage: ${matched.command.usage}`,
     });
     return true;
   }
@@ -98,7 +101,7 @@ function buildHelp(tree: CommandTree<any>) {
   for (const [command, subCommands] of Object.entries(tree)) {
     byCommand[command] = `\
 /${command}
-${subCommands.map((c) => `  ${c.help}`).join("\n")}
+${subCommands.map((c) => `  ${c.usage} - ${c.description}`).join("\n")}
 `;
   }
   const full = `\

--- a/src/lib/cron/command.ts
+++ b/src/lib/cron/command.ts
@@ -2,11 +2,6 @@ import { formatTime, Result } from "../../utils/index.ts";
 import { type CronJob, type CronRun, type CronStore, cronIdSchema } from "./store.ts";
 import { getNextCronSchedule, validateCronSchedule } from "./timer.ts";
 
-export const CRON_ADD_USAGE =
-  "/cron add <id> <minute> <hour> <day-of-month> <month> <day-of-week> [--session <sessionName>] -- <prompt...>";
-export const CRON_UPDATE_USAGE =
-  "/cron update <id> <minute> <hour> <day-of-month> <month> <day-of-week> [--session <sessionName>] [-- <prompt...>]";
-
 export function parseCronArgs(args: string[], timezone: string) {
   const [id, minute, hour, dayOfMonth, month, dayOfWeek, ...restArgs] = args;
   if (!id || !minute || !hour || !dayOfMonth || !month || !dayOfWeek) {


### PR DESCRIPTION
## Summary
- Split command help metadata into structured `usage` and `description` fields
- Render generated help from the structured metadata
- Pass generated `Usage: ...` text into command run contexts

## Test
- pnpm vitest run src/lib/command.test.ts
- pnpm lint

Closes #157