### PR TITLE
refactor!: transpile typescript

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://raw.githubusercontent.com/fallow-rs/fallow/main/schema.json",
-  "entry": ["src/lib/test-agent.ts"]
+  "entry": []
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,6 @@ Task docs should enable **handoff to a fresh agent** - include enough context to
 - Prefer optional properties (`{ x?: T }`) over explicit undefined (`{ x: T | undefined }`)
 - Make props/params required when all call sites always pass them
 - Prefer a single options object over multiple primitive arguments (e.g. `fn({ a, b })` not `fn(a, b)`)
-- Import with `.ts` extensions (NodeNext resolution)
 - Use braces for every `switch` case body (`case "x": { ... }`, `default: { ... }`)
 - When changing setup, CLI commands, service management, session routing, agent registration, customization, cron, or troubleshooting behavior, check whether `README.md` and `skills/acpella` need matching updates.
 - Do not update existing `docs/tasks/*` notes just to reflect code refactors unless explicitly asked.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ Task docs should enable **handoff to a fresh agent** - include enough context to
 
 - Commit messages: use Conventional Commits (`feat:`, `fix:`, `docs:`, `refactor:`, `chore:`); add `!` for breaking changes
 - File names: kebab-case
-- Run `.ts` scripts with `node` (not `tsx`/`ts-node`)
+- Run `.ts` scripts with `tsx`
 - Prefer `undefined` over `null`
 - Prefer optional properties (`{ x?: T }`) over explicit undefined (`{ x: T | undefined }`)
 - Make props/params required when all call sites always pass them

--- a/package.json
+++ b/package.json
@@ -2,12 +2,12 @@
   "name": "acpella",
   "private": true,
   "bin": {
-    "acpella": "./src/bin/cli.ts"
+    "acpella": "./src/bin/cli.js"
   },
   "type": "module",
   "imports": {
-    "#cli": "./src/bin/cli.ts",
-    "#test-agent": "./src/lib/test-agent.ts"
+    "#cli": "./src/bin/cli.js",
+    "#test-agent": "./src/bin/test-agent.js"
   },
   "scripts": {
     "prepare": "vp config",
@@ -28,6 +28,7 @@
     "mdast-util-gfm": "^3.1.0",
     "micromark-extension-gfm": "^3.0.0",
     "temporal-polyfill": "^0.3.2",
+    "tsx": "^4.21.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
   },
   "scripts": {
     "prepare": "vp config",
-    "cli": "node ./src/bin/cli.ts",
-    "dev": "node ./src/bin/cli.ts --env-file .env.dev",
+    "cli": "node ./src/bin/cli.js",
+    "dev": "node ./src/bin/cli.js --env-file .env.dev",
     "test": "vitest --project=unit",
     "test-ci": "CI=true vitest --project=unit --coverage",
     "test-codex": "vitest --project=codex",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       temporal-polyfill:
         specifier: ^0.3.2
         version: 0.3.2
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
       zod:
         specifier: ^4.3.6
         version: 4.3.6

--- a/src/bin/cli.js
+++ b/src/bin/cli.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+import "tsx/esm";
+await import("../cli");

--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -1,2 +1,0 @@
-#!/usr/bin/env node
-import "../cli.ts";

--- a/src/bin/test-agent.js
+++ b/src/bin/test-agent.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+import "tsx/esm";
+await import("../lib/acp/test-agent");

--- a/src/lib/acp/test-agent.ts
+++ b/src/lib/acp/test-agent.ts
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 // Minimal ACP-compatible echo agent for testing.
 // Echoes back the prompt text as an agent_message_chunk.
 

--- a/src/lib/acp/test-agent.ts
+++ b/src/lib/acp/test-agent.ts
@@ -30,7 +30,7 @@ import {
   type CancelNotification,
 } from "@agentclientprotocol/sdk";
 import { z } from "zod";
-import { readJsonFile } from "../utils/fs.ts";
+import { readJsonFile } from "../../utils/fs.ts";
 
 const testAgentStateSchema = z.object({
   nextSessionNumber: z.number().int().min(1),

--- a/src/test/handler.test.ts
+++ b/src/test/handler.test.ts
@@ -128,7 +128,7 @@ test("basic", async () => {
       "defaultAgent": "test",
       "agents": {
         "test": {
-          "command": "node <cwd>/src/lib/test-agent.ts"
+          "command": "node <cwd>/src/bin/test-agent.js"
         }
       },
       "sessions": {
@@ -457,7 +457,7 @@ test("session context usage", async () => {
       "defaultAgent": "test",
       "agents": {
         "test": {
-          "command": "node <cwd>/src/lib/test-agent.ts"
+          "command": "node <cwd>/src/bin/test-agent.js"
         }
       },
       "sessions": {
@@ -551,7 +551,7 @@ test("agent command", async () => {
   `);
   expect(await session.request("/agent list")).toMatchInlineSnapshot(`
     "[⚙️ System]
-    - test -> node <cwd>/src/lib/test-agent.ts (default)"
+    - test -> node <cwd>/src/bin/test-agent.js (default)"
   `);
   expect(await session.request("/agent new test-error no-such-command")).toMatchInlineSnapshot(`
     "[⚙️ System]
@@ -590,7 +590,7 @@ test("agent command", async () => {
   `);
   expect(await session.request("/agent list")).toMatchInlineSnapshot(`
     "[⚙️ System]
-    - test -> node <cwd>/src/lib/test-agent.ts (default)
+    - test -> node <cwd>/src/bin/test-agent.js (default)
     - test-error -> no-such-command"
   `);
   expect(await session.request(`/agent new test2 ${TEST_AGENT_COMMAND}`)).toMatchInlineSnapshot(`
@@ -649,10 +649,10 @@ test("agent command", async () => {
       "defaultAgent": "test2",
       "agents": {
         "test": {
-          "command": "node <cwd>/src/lib/test-agent.ts"
+          "command": "node <cwd>/src/bin/test-agent.js"
         },
         "test2": {
-          "command": "node <cwd>/src/lib/test-agent.ts"
+          "command": "node <cwd>/src/bin/test-agent.js"
         }
       },
       "sessions": {
@@ -688,10 +688,10 @@ test("agent command", async () => {
       "defaultAgent": "test2",
       "agents": {
         "test": {
-          "command": "node <cwd>/src/lib/test-agent.ts"
+          "command": "node <cwd>/src/bin/test-agent.js"
         },
         "test2": {
-          "command": "node <cwd>/src/lib/test-agent.ts"
+          "command": "node <cwd>/src/bin/test-agent.js"
         }
       },
       "sessions": {
@@ -745,7 +745,7 @@ test("state auto reloads external state file changes", async ({ onTestFinished }
   const session = tester.createSession("test");
   expect(await session.request("/agent list")).toMatchInlineSnapshot(`
     "[⚙️ System]
-    - test -> node <cwd>/src/lib/test-agent.ts (default)"
+    - test -> node <cwd>/src/bin/test-agent.js (default)"
   `);
 
   writeJsonFile(tester.config.stateFile, {
@@ -762,7 +762,7 @@ test("state auto reloads external state file changes", async ({ onTestFinished }
   vi.advanceTimersByTime(1250);
   expect(await session.request("/agent list")).toMatchInlineSnapshot(`
     "[⚙️ System]
-    - test -> node <cwd>/src/lib/test-agent.ts (default)
+    - test -> node <cwd>/src/bin/test-agent.js (default)
     - file-agent -> file-agent-command"
   `);
 
@@ -798,7 +798,7 @@ test("state auto reloads external state file changes", async ({ onTestFinished }
 
   expect(await session.request("/agent list")).toMatchInlineSnapshot(`
     "[⚙️ System]
-    - test -> node <cwd>/src/lib/test-agent.ts (default)
+    - test -> node <cwd>/src/bin/test-agent.js (default)
     - file-agent -> file-agent-command"
   `);
 });


### PR DESCRIPTION
- Closes https://github.com/hi-ogawa/acpella/issues/167

This is breaking because
- `acpella` bin path changes `src/bin/cli.ts -> src/bin/cli.js`
  - requires `/service systemd install`
- `test-agent` bin path also changes to `src/lib/test-agent.ts -> src/bin/test-agent.js`
  - `.acpella/state.json` `agents` map needs to be updated manually if `test` agent exists