### PR TITLE
docs: clarify acpella slash command skill triggers

### DIFF
--- a/skills/acpella/SKILL.md
+++ b/skills/acpella/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: acpella
 description: >-
-  Use when helping someone use or customize acpella itself: first-time setup,
-  CLI usage for slash-command administration, systemd service setup, prompt and
-  skill customization, session and agent management, cron jobs, or
-  troubleshooting.
+  Use when helping someone use or customize acpella itself: slash commands
+  including /agent, /session, /cron, /status, /service, and /help; first-time
+  setup; CLI usage; systemd service setup; prompt and skill customization;
+  session and agent management; cron jobs; or troubleshooting.
 ---
 
 # acpella


### PR DESCRIPTION
## Summary

- Mention top-level acpella slash commands directly in the acpella skill frontmatter.
- Improve skill routing for prompts like `/agent list` before the skill body is loaded.

Closes #179.

## Test

- `pnpm lint`