### PR TITLE
feat: add `/agent sessions` and remove acp session info from `/session list`

### DIFF
--- a/skills/acpella/references/sessions-and-agents.md
+++ b/skills/acpella/references/sessions-and-agents.md
@@ -15,13 +15,14 @@ In practice, session commands are for:
 
 Run session lifecycle commands from Telegram or the REPL conversation whose context you mean to control. Do not use `acpella exec` for `/session new`, `/session load`, or `/session close`. Use `acpella exec /session list` and `acpella exec '/session info <sessionName>'` only to discover existing session names and inspect known sessions for administrative commands such as cron creation.
 
+`/session list` is a local acpella state view. It reads `.acpella/state.json` only; it does not connect to ACP backends, verify mapped backend sessions, or discover unmapped backend sessions.
+
 ## Session commands
 
 Use:
 
 - `/session info [sessionName]`
 - `/session list`
-- `/session list --all`
 - `/session new [agent]`
 - `/session load <sessionId|agent:sessionId>`
 - `/session close [sessionId|agent:sessionId]`
@@ -33,10 +34,12 @@ Common cases:
 - if you want a clean start, run `/session new`
 - if you know an older ACP session id, use `/session load ...`
 - use `/session info [sessionName]` to inspect the selected agent, agent session id, verbose setting, renewal policy, and context usage
-- use `/session list` to see all mapped acpella sessions; add `--all` to also show unmapped backend sessions
+- use `/session list` to see all mapped acpella sessions without probing backend agents
 - use `/session config` to show or update per-session settings (`verbose`, `renew`) in one place
 - use `/session config verbose=off|tool|thinking|all` to control internal progress output for a session
 - use `/session config renew=off|daily|daily:<hour>` to change whether a session renews automatically
+
+`/session list` should show acpella session names, their selected agent, mapped agent session id when present, renewal policy, and cached context usage when available.
 
 ### `/session config` examples
 
@@ -69,9 +72,12 @@ Examples:
 Use:
 
 - `/agent list`
+- `/agent sessions [agent]`
 - `/agent new <name> <command...>`
 - `/agent remove <name>`
 - `/agent default [name]`
+
+Use `/agent sessions [agent]` only when a human operator explicitly wants backend ACP session discovery. It may start or connect to configured agent processes and should report backend failures as diagnostics. Agents should not use it for routine administration or session selection; prefer `/session list` and `/session info <sessionName>` unless the user specifically asks to inspect backend agent sessions.
 
 Typical flow:
 

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -420,23 +420,24 @@ renew: ${renderSessionRenewPolicy({ policy: stateSession.renew, timezone: config
             const manager = await getAgentManager(agentKey);
             const agentSessions = await manager.listSessions();
             const sessions = agentSessions.sessions;
-            let entry = `${agentKey}:`;
+            let entry = `${agentKey}:\n`;
             if (sessions.length === 0) {
-              entry += "\nnone";
+              entry += "  none";
             } else {
               for (const session of sessions) {
-                entry += `\n- ${session.sessionId}`;
+                entry += `- ${session.sessionId}\n`;
               }
             }
             output.push(entry);
           } catch (error) {
             output.push(`\
 ${agentKey}:
-error: ${formatError(error)}`);
+  error: ${formatError(error)}
+`);
           }
         }
 
-        await reply.system(output.join("\n\n") || "No agents.");
+        await reply.system(output.join("\n") || "No agents.");
       },
     },
     {

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -414,7 +414,11 @@ renew: ${renderSessionRenewPolicy({ policy: stateSession.renew, timezone: config
           return;
         }
 
-        const output: string[] = [];
+        if (agentKeys.length === 0) {
+          await reply.system("No agents.");
+          return;
+        }
+
         for (const agentKey of agentKeys) {
           try {
             const manager = await getAgentManager(agentKey);
@@ -428,16 +432,14 @@ renew: ${renderSessionRenewPolicy({ policy: stateSession.renew, timezone: config
                 entry += `- ${session.sessionId}\n`;
               }
             }
-            output.push(entry);
+            await reply.system(entry);
           } catch (error) {
-            output.push(`\
+            await reply.system(`\
 ${agentKey}:
   error: ${formatError(error)}
 `);
           }
         }
-
-        await reply.system(output.join("\n") || "No agents.");
       },
     },
     {

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -249,64 +249,31 @@ renew: ${renderSessionRenewPolicy({ policy: stateSession.renew, timezone: config
     },
     {
       tokens: ["list"],
-      usage: "/session list [--all]",
-      description: "List known agent sessions.",
-      withArgs: true,
-      run: async ({ reply, args }) => {
+      usage: "/session list",
+      description: "List known acpella sessions.",
+      run: async ({ reply }) => {
         const state = stateStore.get();
-        const activeAgentSessions = new Set<string>();
-        for (const [agentKey] of Object.entries(state.agents)) {
-          try {
-            const manager = await getAgentManager(agentKey);
-            const agentSessions = await manager.listSessions();
-            for (const session of agentSessions.sessions) {
-              activeAgentSessions.add(
-                toAgentSessionKey({ agentKey, agentSessionId: session.sessionId }),
-              );
-            }
-          } catch (e) {
-            // TODO: include errored agent in message response
-            console.error(`[acp] listSessions failed for agent ${agentKey}:`, e);
-          }
-        }
-        const stateAgentSessions = new Map<string, string>();
+        const output: string[] = [];
         for (const [sessionName, stateSession] of Object.entries(state.sessions)) {
-          if (stateSession.agentKey && stateSession.agentSessionId) {
-            stateAgentSessions.set(
-              toAgentSessionKey({
-                agentKey: stateSession.agentKey,
-                agentSessionId: stateSession.agentSessionId,
-              }),
-              sessionName,
-            );
-          }
-        }
-        let mappedOutput = "";
-        for (const [agentSessionKey, sessionName] of stateAgentSessions) {
-          mappedOutput += `- ${sessionName} -> ${agentSessionKey}`;
-          if (!activeAgentSessions.has(agentSessionKey)) {
-            mappedOutput += " (not found)";
-          }
-          mappedOutput += "\n";
-        }
-        if (args.includes("--all")) {
-          let output = `\
-Mapped sessions:
-${mappedOutput || "none\n"}
-Unmapped acp sessions:
+          let entry = `\
+- ${sessionName}
+  agent: ${stateSession.agentKey}
+  agent session: ${stateSession.agentSessionId ?? "none"}
+  renew: ${renderSessionRenewPolicy({ policy: stateSession.renew, timezone: config.timezone })}
 `;
-          const unmapped = [...activeAgentSessions].filter((k) => !stateAgentSessions.has(k));
-          if (unmapped.length === 0) {
-            output += "none\n";
-          } else {
-            for (const agentSessionKey of unmapped) {
-              output += `- ${agentSessionKey}\n`;
+          if (stateSession.agentSessionId) {
+            const usage = stateStore.getAgentSessionUsage({
+              agentKey: stateSession.agentKey,
+              agentSessionId: stateSession.agentSessionId,
+            });
+            if (usage) {
+              const pct = Math.round((usage.used / usage.size) * 100);
+              entry += `  context: ${usage.used} / ${usage.size} tokens (${pct}%)`;
             }
           }
-          await reply.system(output);
-        } else {
-          await reply.system(mappedOutput || "No sessions.");
+          output.push(entry);
         }
+        await reply.system(output.join("\n\n") || "No sessions.");
       },
     },
     {
@@ -431,6 +398,45 @@ Unmapped acp sessions:
           response += `- ${agentKey} -> ${agent.command}${marker}\n`;
         }
         await reply.system(response || "No agents.");
+      },
+    },
+    {
+      tokens: ["sessions"],
+      usage: "/agent sessions [agent]",
+      description: "List backend ACP sessions.",
+      withArgs: true,
+      run: async ({ args, reply }) => {
+        const state = stateStore.get();
+        const requestedAgent = args[0];
+        const agentKeys = requestedAgent ? [requestedAgent] : Object.keys(state.agents);
+        if (requestedAgent && !state.agents[requestedAgent]) {
+          await reply.system(`Unknown agent: ${requestedAgent}`);
+          return;
+        }
+
+        const output: string[] = [];
+        for (const agentKey of agentKeys) {
+          try {
+            const manager = await getAgentManager(agentKey);
+            const agentSessions = await manager.listSessions();
+            const sessions = agentSessions.sessions;
+            let entry = `${agentKey}:`;
+            if (sessions.length === 0) {
+              entry += "\nnone";
+            } else {
+              for (const session of sessions) {
+                entry += `\n- ${session.sessionId}`;
+              }
+            }
+            output.push(entry);
+          } catch (error) {
+            output.push(`\
+${agentKey}:
+error: ${formatError(error)}`);
+          }
+        }
+
+        await reply.system(output.join("\n\n") || "No agents.");
       },
     },
     {

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -250,7 +250,7 @@ renew: ${renderSessionRenewPolicy({ policy: stateSession.renew, timezone: config
     {
       tokens: ["list"],
       usage: "/session list",
-      description: "List known acpella sessions.",
+      description: "List acpella sessions.",
       run: async ({ reply }) => {
         const state = stateStore.get();
         const output: string[] = [];

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -407,13 +407,13 @@ renew: ${renderSessionRenewPolicy({ policy: stateSession.renew, timezone: config
       withArgs: true,
       run: async ({ args, reply }) => {
         const state = stateStore.get();
-        const requestedAgent = args[0];
-        const agentKeys = requestedAgent ? [requestedAgent] : Object.keys(state.agents);
-        if (requestedAgent && !state.agents[requestedAgent]) {
-          await reply.system(`Unknown agent: ${requestedAgent}`);
+        const agentArg = args[0];
+        if (agentArg && !state.agents[agentArg]) {
+          await reply.system(`Unknown agent: ${agentArg}`);
           return;
         }
 
+        const agentKeys = agentArg ? [agentArg] : Object.keys(state.agents);
         if (agentKeys.length === 0) {
           await reply.system("No agents.");
           return;

--- a/src/test/handler.test.ts
+++ b/src/test/handler.test.ts
@@ -643,7 +643,7 @@ test("agent command", async () => {
   expect(await session.request("/agent sessions")).toMatchInlineSnapshot(`
     "[⚙️ System]
     test:
-    none"
+      none"
   `);
   expect(await session.request("/agent new test-error no-such-command")).toMatchInlineSnapshot(`
     "[⚙️ System]
@@ -652,7 +652,7 @@ test("agent command", async () => {
   expect(await session.request("/agent sessions test-error")).toMatchInlineSnapshot(`
     "[⚙️ System]
     test-error:
-    error: ACP agent failed to start: spawn no-such-command ENOENT"
+      error: ACP agent failed to start: spawn no-such-command ENOENT"
   `);
   expect(await session.request("/session new test-error")).toMatchInlineSnapshot(`
     "[⚙️ System]

--- a/src/test/handler.test.ts
+++ b/src/test/handler.test.ts
@@ -30,10 +30,8 @@ Coverage checklist:
   - [ ] close current session
   - [ ] close deletes matching state session
   - [ ] close reports closeSession failure
-  - [x] list
+  - [x] list local state only
   - [ ] list with multiple agents
-  - [ ] list marks stored inactive sessions as not active
-  - [ ] list tolerates listSessions failure for one agent
   - [x] verbose tool
   - [x] verbose off
   - [x] verbose suppresses tool call output
@@ -42,6 +40,8 @@ Coverage checklist:
   - [x] renew stale session when chat prompt crosses daily boundary
 - /agent
   - [x] list
+  - [x] sessions
+  - [x] sessions reports backend failures
   - [x] bare usage output
   - [x] new
   - [x] auto reloads external state file changes
@@ -87,7 +87,7 @@ test("basic", async () => {
 
     /session
       /session info [sessionName] - Show info about a session.
-      /session list [--all] - List known agent sessions.
+      /session list - List acpella sessions.
       /session new [agent] - Start a new agent session.
       /session load <sessionId|agent:sessionId> - Load an existing agent session.
       /session close [sessionId|agent:sessionId] - Close an agent session.
@@ -95,6 +95,7 @@ test("basic", async () => {
 
     /agent
       /agent list - List configured agents.
+      /agent sessions [agent] - List backend ACP sessions.
       /agent new <name> <command...> - Save a new agent.
       /agent remove <name> - Remove an agent.
       /agent default [name] - Show or set the default agent.
@@ -317,7 +318,7 @@ test("session commands", async () => {
     "[⚙️ System]
     /session
       /session info [sessionName] - Show info about a session.
-      /session list [--all] - List known agent sessions.
+      /session list - List acpella sessions.
       /session new [agent] - Start a new agent session.
       /session load <sessionId|agent:sessionId> - Load an existing agent session.
       /session close [sessionId|agent:sessionId] - Close an agent session.
@@ -327,7 +328,7 @@ test("session commands", async () => {
     "[⚙️ System]
     /session
       /session info [sessionName] - Show info about a session.
-      /session list [--all] - List known agent sessions.
+      /session list - List acpella sessions.
       /session new [agent] - Start a new agent session.
       /session load <sessionId|agent:sessionId> - Load an existing agent session.
       /session close [sessionId|agent:sessionId] - Close an agent session.
@@ -345,14 +346,6 @@ test("session commands", async () => {
     "[⚙️ System]
     No sessions."
   `);
-  expect(await session.request("/session list --all")).toMatchInlineSnapshot(`
-    "[⚙️ System]
-    Mapped sessions:
-    none
-
-    Unmapped acp sessions:
-    none"
-  `);
   expect(await session.request("hello")).toMatchInlineSnapshot(`"echo: hello"`);
   expect(await session.request("/session info")).toMatchInlineSnapshot(`
     "[⚙️ System]
@@ -364,7 +357,10 @@ test("session commands", async () => {
   `);
   expect(await session.request("/session list")).toMatchInlineSnapshot(`
     "[⚙️ System]
-    - test -> test:__testSession1"
+    - test
+      agent: test
+      agent session: __testSession1
+      renew: off"
   `);
   expect(await session.request("/session load")).toMatchInlineSnapshot(`
     "[⚙️ System]
@@ -386,15 +382,16 @@ test("session commands", async () => {
   expect(await session.request("__session")).toMatchInlineSnapshot(`"session: __testSession2"`);
   expect(await session.request("/session list")).toMatchInlineSnapshot(`
     "[⚙️ System]
-    - test -> test:__testSession2"
+    - test
+      agent: test
+      agent session: __testSession2
+      renew: off"
   `);
-  expect(await session.request("/session list --all")).toMatchInlineSnapshot(`
+  expect(await session.request("/agent sessions")).toMatchInlineSnapshot(`
     "[⚙️ System]
-    Mapped sessions:
-    - test -> test:__testSession2
-
-    Unmapped acp sessions:
-    - test:__testSession1"
+    test:
+    - __testSession1
+    - __testSession2"
   `);
   expect(await session.request("/session new no-such-agent")).toMatchInlineSnapshot(
     `
@@ -634,6 +631,7 @@ test("agent command", async () => {
     "[⚙️ System]
     /agent
       /agent list - List configured agents.
+      /agent sessions [agent] - List backend ACP sessions.
       /agent new <name> <command...> - Save a new agent.
       /agent remove <name> - Remove an agent.
       /agent default [name] - Show or set the default agent."
@@ -642,9 +640,19 @@ test("agent command", async () => {
     "[⚙️ System]
     - test -> node <cwd>/src/bin/test-agent.js (default)"
   `);
+  expect(await session.request("/agent sessions")).toMatchInlineSnapshot(`
+    "[⚙️ System]
+    test:
+    none"
+  `);
   expect(await session.request("/agent new test-error no-such-command")).toMatchInlineSnapshot(`
     "[⚙️ System]
     Saved new agent: test-error"
+  `);
+  expect(await session.request("/agent sessions test-error")).toMatchInlineSnapshot(`
+    "[⚙️ System]
+    test-error:
+    error: ACP agent failed to start: spawn no-such-command ENOENT"
   `);
   expect(await session.request("/session new test-error")).toMatchInlineSnapshot(`
     "[⚙️ System]
@@ -726,7 +734,10 @@ test("agent command", async () => {
   `);
   expect(await session.request("/session list")).toMatchInlineSnapshot(`
     "[⚙️ System]
-    - test -> test2:__testSession1"
+    - test
+      agent: test2
+      agent session: __testSession1
+      renew: off"
   `);
   expect(await session.request("/agent remove test-error")).toMatchInlineSnapshot(`
     "[⚙️ System]


### PR DESCRIPTION
- Closes https://github.com/hi-ogawa/acpella/issues/201

TODO
- [ ] (follow up) move utils to lib/session/command.ts https://github.com/hi-ogawa/acpella/issues/203