### PR TITLE
refactor: simplify cron id parsing

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -674,13 +674,8 @@ enabled jobs: ${enabledJobs.length}
       usage: "/cron show <id>",
       description: "Show a cron job.",
       withArgs: true,
-      run: async ({ args, reply, usage }) => {
-        const parsed = parseCronIdArg(args, usage);
-        if (!parsed.ok) {
-          await reply.system(parsed.value);
-          return;
-        }
-        const { id } = parsed.value;
+      run: async ({ args, reply }) => {
+        const id = parseCronIdArg(args);
         const job = cronStore.getJob(id);
         if (!job) {
           await reply.system(`Unknown cron job: ${id}`);
@@ -694,13 +689,8 @@ enabled jobs: ${enabledJobs.length}
       usage: "/cron enable <id>",
       description: "Enable a cron job.",
       withArgs: true,
-      run: async ({ args, reply, usage }) => {
-        const parsed = parseCronIdArg(args, usage);
-        if (!parsed.ok) {
-          await reply.system(parsed.value);
-          return;
-        }
-        const { id } = parsed.value;
+      run: async ({ args, reply }) => {
+        const id = parseCronIdArg(args);
         if (!cronStore.getJob(id)) {
           await reply.system(`Unknown cron job: ${id}`);
           return;
@@ -719,13 +709,8 @@ enabled jobs: ${enabledJobs.length}
       usage: "/cron disable <id>",
       description: "Disable a cron job.",
       withArgs: true,
-      run: async ({ args, reply, usage }) => {
-        const parsed = parseCronIdArg(args, usage);
-        if (!parsed.ok) {
-          await reply.system(parsed.value);
-          return;
-        }
-        const { id } = parsed.value;
+      run: async ({ args, reply }) => {
+        const id = parseCronIdArg(args);
         if (!cronStore.getJob(id)) {
           await reply.system(`Unknown cron job: ${id}`);
           return;
@@ -744,13 +729,8 @@ enabled jobs: ${enabledJobs.length}
       usage: "/cron delete <id>",
       description: "Delete a cron job.",
       withArgs: true,
-      run: async ({ args, reply, usage }) => {
-        const parsed = parseCronIdArg(args, usage);
-        if (!parsed.ok) {
-          await reply.system(parsed.value);
-          return;
-        }
-        const { id } = parsed.value;
+      run: async ({ args, reply }) => {
+        const id = parseCronIdArg(args);
         if (!cronStore.getJob(id)) {
           await reply.system(`Unknown cron job: ${id}`);
           return;

--- a/src/lib/cron/command.ts
+++ b/src/lib/cron/command.ts
@@ -1,4 +1,4 @@
-import { formatTime, Result } from "../../utils/index.ts";
+import { formatTime } from "../../utils/index.ts";
 import { type CronJob, type CronRun, type CronStore, cronIdSchema } from "./store.ts";
 import { getNextCronSchedule, validateCronSchedule } from "./timer.ts";
 
@@ -46,16 +46,16 @@ export function parseCronArgs(args: string[], timezone: string) {
   return { id, schedule, target, once, prompt };
 }
 
-export function parseCronIdArg(args: string[], usage: string): Result<{ id: string }, string> {
+export function parseCronIdArg(args: string[]): string {
   const id = args[0];
   if (!id || args.length !== 1) {
-    return Result.err(usage);
+    throw new Error("Invalid input");
   }
   const cronIdResult = cronIdSchema.safeParse(id);
   if (!cronIdResult.success) {
-    return Result.err("Invalid cron id. Use letters, numbers, underscores, or hyphens.");
+    throw new Error("Invalid cron id. Use letters, numbers, underscores, or hyphens.");
   }
-  return Result.ok({ id });
+  return id;
 }
 
 export function renderCronList(cronStore: CronStore): string {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -51,12 +51,6 @@ export function formatError(error: unknown): string {
   return String(error);
 }
 
-export type Result<T, E> = { ok: true; value: T } | { ok: false; value: E };
-export const Result = {
-  ok: <T>(value: T): Result<T, never> => ({ ok: true, value }),
-  err: <E>(value: E): Result<never, E> => ({ ok: false, value }),
-};
-
 export class AsyncIterableQueue<T> {
   private queue: T[] = [];
   private notify: (() => void) | undefined;


### PR DESCRIPTION
## Summary
- Change `parseCronIdArg` to throw parser errors directly and return the cron id string
- Remove `Result` handling from cron show/enable/disable/delete command handlers

## Verification
- Commit hook ran `vp check --fix` for staged files