### PR TITLE
fix: include weekday in compact cron list

### DIFF
--- a/src/lib/cron/command.ts
+++ b/src/lib/cron/command.ts
@@ -175,10 +175,11 @@ function formatCronNext(job: CronJob): string {
 function formatCronCompactDateTime(time: number, timezone: string): string {
   const zoned = Temporal.Instant.fromEpochMilliseconds(time).toZonedDateTimeISO(timezone);
   const month = MONTH_NAMES[zoned.month - 1]!;
-  const day = String(zoned.day).padStart(2, " ");
+  const day = String(zoned.day);
+  const weekday = WEEKDAY_NAMES[zoned.dayOfWeek - 1]!;
   const hour = String(zoned.hour).padStart(2, "0");
   const minute = String(zoned.minute).padStart(2, "0");
-  return `${month} ${day} | ${hour}:${minute}`;
+  return `${month} ${day} (${weekday}) | ${hour}:${minute}`;
 }
 
 function formatCronCompactMarkers(job: CronJob, latestRun?: CronRun): string {
@@ -202,6 +203,8 @@ const MONTH_NAMES = [
   "Nov",
   "Dec",
 ];
+
+const WEEKDAY_NAMES = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
 
 function formatCronLastRun(run: CronRun | undefined, timezone: string): string {
   if (!run) {

--- a/src/test/cron.test.ts
+++ b/src/test/cron.test.ts
@@ -207,7 +207,7 @@ test("cron command", async ({ onTestFinished }) => {
   `);
   expect(await session.request("/cron list --compact")).toMatchInlineSnapshot(`
     "[⚙️ System]
-    Apr 18 | 07:01 | test-job"
+    Apr 18 (Sat) | 07:01 | test-job"
   `);
   expect(await session.request("/cron show test-job")).toMatchInlineSnapshot(`
     "[⚙️ System]
@@ -307,7 +307,7 @@ test("cron command", async ({ onTestFinished }) => {
   `);
   expect(await session.request("/cron list --compact")).toMatchInlineSnapshot(`
     "[⚙️ System]
-    Apr 18 | 07:03 | other-job
+    Apr 18 (Sat) | 07:03 | other-job
 
     disabled:
     - test-job"
@@ -538,7 +538,7 @@ test("cron error delivery", async ({ onTestFinished }) => {
   `);
   expect(await session.request("/cron list --compact")).toMatchInlineSnapshot(`
     "[⚙️ System]
-    Apr 18 | 07:02 | test-job (failed)"
+    Apr 18 (Sat) | 07:02 | test-job (failed)"
   `);
 });
 
@@ -838,7 +838,7 @@ test("cron one-shot: disabled after successful run", async ({ onTestFinished }) 
   `);
   expect(await session.request("/cron list --compact")).toMatchInlineSnapshot(`
     "[⚙️ System]
-    Apr 18 | 07:01 | once-job (once)"
+    Apr 18 (Sat) | 07:01 | once-job (once)"
   `);
 
   advanceTimersTo("2026-04-18T07:01:00+07:00");


### PR DESCRIPTION
## Summary
- include weekday names in /cron list --compact date output
- update compact cron list snapshots for the new format

## Verification
- staged-file hook ran during commit: vp check --fix
- not run: pnpm test