### PR TITLE
refactor: use disposables for CLI cleanup

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -178,6 +178,8 @@ ${CLI_HELP}`);
       logLabel: label,
     });
     chatActionManager.start();
+    await using cleanup = new AsyncDisposableStack();
+    cleanup.defer(() => chatActionManager.stop());
 
     const replyWithRetry = async (...args: Parameters<typeof ctx.reply>) => {
       try {
@@ -243,8 +245,6 @@ ${CLI_HELP}`);
       const name = error instanceof Error ? error.name : "Error";
       const message = error instanceof Error ? error.message : String(error);
       await replyWithRetry(`${name}: ${truncateString(message, 200)}`);
-    } finally {
-      chatActionManager.stop();
     }
   });
 
@@ -283,7 +283,7 @@ async function startRepl({
     }
   }
 
-  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  using rl = createInterface({ input: process.stdin, output: process.stdout });
 
   let cancelRequested = false;
   rl.on("SIGINT", () => {
@@ -312,8 +312,6 @@ async function startRepl({
     if (!(e instanceof Error && e.name === "AbortError")) {
       throw e;
     }
-  } finally {
-    rl.close();
   }
 }
 


### PR DESCRIPTION
## Summary
- use an AsyncDisposableStack for Telegram chat action cleanup
- use readline's disposable interface for REPL cleanup

## Tests
- pnpm lint-check