### PR TITLE
fix: preserve structured request errors

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,6 +19,7 @@ import {
 } from "./lib/telegram/utils.ts";
 import { getVersion } from "./lib/version.ts";
 import { addIndent, sleep, truncateString } from "./utils/index.ts";
+import { stringifyError } from "./utils/node.ts";
 
 const CLI_HELP = `\
 Usage: acpella [command]
@@ -253,9 +254,7 @@ ${CLI_HELP}`);
         return;
       }
       console.error(`${label} (response error)`, error);
-      const name = error instanceof Error ? error.name : "Error";
-      const message = error instanceof Error ? error.message : String(error);
-      await replyWithRetry(`${name}: ${truncateString(message, 200)}`);
+      await replyWithRetry(`[acpella error]\n${truncateString(stringifyError(error), 2000)}`);
     }
   }
 

--- a/src/lib/cron/runner.ts
+++ b/src/lib/cron/runner.ts
@@ -1,5 +1,6 @@
 import { FileWatcher } from "../../utils/fs.ts";
 import { formatError, formatTime } from "../../utils/index.ts";
+import { stringifyError } from "../../utils/node.ts";
 import type { CronJob, CronStore, CronDeliveryTarget } from "./store.ts";
 import { CronScheduler, type CronDueEvent } from "./timer.ts";
 
@@ -119,7 +120,7 @@ ${response}`;
       });
     } catch (error) {
       console.error(`[cron] Failed to run cron '${job.id}':`, error);
-      const errorMessage = formatError(error);
+      const errorMessage = stringifyError(error);
       store.updateRun(run.id, {
         finishedAt: formatTime(Date.now()),
         status: "failed",

--- a/src/test/cron.test.ts
+++ b/src/test/cron.test.ts
@@ -519,7 +519,7 @@ test("cron error delivery", async ({ onTestFinished }) => {
     session_name: test
 
     Error:
-    Internal error
+    RequestError: { message: 'Internal error' }
     ",
     ]
   `);
@@ -533,7 +533,7 @@ test("cron error delivery", async ({ onTestFinished }) => {
     target session: test
     delivery target: repl
     next: 2026-04-18T07:02:00+07:00
-    last: failed, scheduled 2026-04-18T07:01:00+07:00, finished 2026-04-18T07:01:00+07:00, error: Internal error
+    last: failed, scheduled 2026-04-18T07:01:00+07:00, finished 2026-04-18T07:01:00+07:00, error: RequestError: { message: 'Internal error' }
     prompt: __throw_error__"
   `);
   expect(await session.request("/cron list --compact")).toMatchInlineSnapshot(`
@@ -921,7 +921,7 @@ test("cron one-shot: disabled after failed run", async ({ onTestFinished }) => {
     target session: test
     delivery target: repl
     next: none
-    last: failed, scheduled 2026-04-18T07:01:00+07:00, finished 2026-04-18T07:01:00+07:00, error: Internal error
+    last: failed, scheduled 2026-04-18T07:01:00+07:00, finished 2026-04-18T07:01:00+07:00, error: RequestError: { message: 'Internal error' }
     prompt: __throw_error__"
   `);
 });

--- a/src/test/cron.test.ts
+++ b/src/test/cron.test.ts
@@ -519,7 +519,12 @@ test("cron error delivery", async ({ onTestFinished }) => {
     session_name: test
 
     Error:
-    RequestError: { message: 'Internal error' }
+    RequestError: {
+      message: 'Internal error',
+      code: -32603,
+      data: { details: 'simulated error' },
+      name: 'RequestError'
+    }
     ",
     ]
   `);
@@ -533,7 +538,12 @@ test("cron error delivery", async ({ onTestFinished }) => {
     target session: test
     delivery target: repl
     next: 2026-04-18T07:02:00+07:00
-    last: failed, scheduled 2026-04-18T07:01:00+07:00, finished 2026-04-18T07:01:00+07:00, error: RequestError: { message: 'Internal error' }
+    last: failed, scheduled 2026-04-18T07:01:00+07:00, finished 2026-04-18T07:01:00+07:00, error: RequestError: {
+      message: 'Internal error',
+      code: -32603,
+      data: { details: 'simulated error' },
+      name: 'RequestError'
+    }
     prompt: __throw_error__"
   `);
   expect(await session.request("/cron list --compact")).toMatchInlineSnapshot(`
@@ -921,7 +931,12 @@ test("cron one-shot: disabled after failed run", async ({ onTestFinished }) => {
     target session: test
     delivery target: repl
     next: none
-    last: failed, scheduled 2026-04-18T07:01:00+07:00, finished 2026-04-18T07:01:00+07:00, error: RequestError: { message: 'Internal error' }
+    last: failed, scheduled 2026-04-18T07:01:00+07:00, finished 2026-04-18T07:01:00+07:00, error: RequestError: {
+      message: 'Internal error',
+      code: -32603,
+      data: { details: 'simulated error' },
+      name: 'RequestError'
+    }
     prompt: __throw_error__"
   `);
 });

--- a/src/utils/node.ts
+++ b/src/utils/node.ts
@@ -2,12 +2,10 @@ import { inspect } from "node:util";
 
 export function stringifyError(error: unknown): string {
   if (error instanceof Error) {
-    const fields: Record<PropertyKey, unknown> = {};
-    Object.assign(fields, error);
-    delete fields.message;
+    const { message, ...fields } = error;
     return `${error.name}: ${inspect(
       {
-        message: error.message,
+        message,
         ...fields,
       },
       { depth: 10 },

--- a/src/utils/node.ts
+++ b/src/utils/node.ts
@@ -1,0 +1,17 @@
+import { inspect } from "node:util";
+
+export function stringifyError(error: unknown): string {
+  if (error instanceof Error) {
+    const fields: Record<PropertyKey, unknown> = {};
+    Object.assign(fields, error);
+    delete fields.message;
+    return `${error.name}: ${inspect(
+      {
+        message: error.message,
+        ...fields,
+      },
+      { depth: 10 },
+    )}`;
+  }
+  return inspect(error, { depth: 10 });
+}


### PR DESCRIPTION
## Summary
- add a Node-specific error serializer that inspects Error message plus enumerable fields
- use serialized errors for Telegram response failures with an acpella error prefix
- use serialized errors in cron failure storage and delivery messages

Fixes #216

## Tests
- pre-commit hook ran `vp check --fix`