### PR TITLE
chore(deps): bump opencode sdk

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@agentclientprotocol/sdk": "^0.18.2",
     "@grammyjs/runner": "^2.0.3",
-    "@opencode-ai/sdk": "^1.14.29",
+    "@opencode-ai/sdk": "^1.15.10",
     "croner": "^10.0.1",
     "grammy": "^1.42.0",
     "mdast-util-from-markdown": "^2.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^2.0.3
         version: 2.0.3(grammy@1.42.0)
       '@opencode-ai/sdk':
-        specifier: ^1.14.29
-        version: 1.14.29
+        specifier: ^1.15.10
+        version: 1.15.10
       croner:
         specifier: ^10.0.1
         version: 10.0.1
@@ -325,8 +325,8 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
-  '@opencode-ai/sdk@1.14.29':
-    resolution: {integrity: sha512-y6wNTlHhgfwLdp01EwdnMFVxUS1FLgz7MZh7H3+jROG2v02GqGDy/gPH3ME0kI+sqQ4qSlk/9AJ+YbKAruPaZw==}
+  '@opencode-ai/sdk@1.15.10':
+    resolution: {integrity: sha512-CUhpmMGGOqzvPnNNjjWmEIodAfP6Qnuki2ChIUKWYF7UImZ4zUcMZnzO5BtUxu/Ni1P8qzWxDioXs+7aIZQEhA==}
 
   '@oxc-project/runtime@0.123.0':
     resolution: {integrity: sha512-wRf0z8saz9tHLcK3YeTeBmwISrpy4bBimvKxUmryiIhbt+ZJb0nwwJNL3D8xpeWbNfZlGSlzRBZbfcbApIGZJw==}
@@ -1724,7 +1724,7 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@opencode-ai/sdk@1.14.29':
+  '@opencode-ai/sdk@1.15.10':
     dependencies:
       cross-spawn: 7.0.6
 


### PR DESCRIPTION
## Summary
- Bump `@opencode-ai/sdk` from `^1.14.29` to `^1.15.10`
- Refresh `pnpm-lock.yaml` for the new SDK version

## Validation
- `pnpm lint`
- `pnpm test-opencode`