### PR TITLE
feat(opencode): support model options

### DIFF
--- a/skills/acpella/references/agents/opencode.md
+++ b/skills/acpella/references/agents/opencode.md
@@ -38,12 +38,6 @@ Pass repeated `--model-option <key=value>` flags to set OpenCode per-model optio
 acpella exec /agent new opencode acpella-opencode-acp --model openai/gpt-5 --model-option reasoningEffort=high
 ```
 
-Dotted option keys create nested option objects:
-
-```bash
-acpella exec /agent new opencode acpella-opencode-acp --model anthropic/claude-sonnet-4-5-20250929 --model-option thinking.type=enabled --model-option thinking.budgetTokens=16000
-```
-
 ## OpenCode Feature Flags
 
 OpenCode gates some features behind environment variables. Bake those into the registered agent command when needed.

--- a/skills/acpella/references/agents/opencode.md
+++ b/skills/acpella/references/agents/opencode.md
@@ -32,6 +32,18 @@ acpella exec /agent new opencode acpella-opencode-acp --model openai/gpt-5.5
 
 Use `opencode models` to list available provider/model values before choosing the `--model` target.
 
+Pass repeated `--model-option <key=value>` flags to set OpenCode per-model options for the selected model:
+
+```bash
+acpella exec /agent new opencode acpella-opencode-acp --model openai/gpt-5 --model-option reasoningEffort=high
+```
+
+Dotted option keys create nested option objects:
+
+```bash
+acpella exec /agent new opencode acpella-opencode-acp --model anthropic/claude-sonnet-4-5-20250929 --model-option thinking.type=enabled --model-option thinking.budgetTokens=16000
+```
+
 ## OpenCode Feature Flags
 
 OpenCode gates some features behind environment variables. Bake those into the registered agent command when needed.

--- a/src/lib/opencode/agent.test.ts
+++ b/src/lib/opencode/agent.test.ts
@@ -79,6 +79,7 @@ it("stops the opencode server child process when the adapter stops", async () =>
 
 it("model options", async () => {
   // https://opencode.ai/docs/models/#configure-models
+  // https://github.com/anomalyco/opencode/blob/dbb787232605f5293945edc5b1ac14856e5d43e3/packages/llm/src/providers/openai-options.ts#L7
   const { root } = useFs({ prefix: "opencode-acp-model-options" });
   const manager = new AgentManager({
     command: `${OPENCODE_ACP_COMMAND} --model openai/gpt-5.2 --model-option reasoningEffort=low`,

--- a/src/lib/opencode/agent.test.ts
+++ b/src/lib/opencode/agent.test.ts
@@ -77,6 +77,23 @@ it("stops the opencode server child process when the adapter stops", async () =>
   await expect.poll(() => processExists(serverPid)).toBe(false);
 });
 
+it("model options", async () => {
+  // https://opencode.ai/docs/models/#configure-models
+  const { root } = useFs({ prefix: "opencode-acp-model-options" });
+  const manager = new AgentManager({
+    command: `${OPENCODE_ACP_COMMAND} --model openai/gpt-5.2 --model-option reasoningEffort=low`,
+    cwd: root,
+  });
+
+  const session = await manager.newSession({ sessionCwd: root });
+  onTestFinished(() => session.stop());
+
+  const result = session.prompt("Say exactly: world");
+  const updates = await arrayFromAsyncIterator(result.consume());
+  await expect(result.promise).resolves.toEqual({ stopReason: "end_turn" });
+  expect(textFromUpdates(updates).toLowerCase()).toContain("world");
+});
+
 function textFromUpdates(updates: SessionUpdate[]) {
   return updates
     .map((update) => {

--- a/src/lib/opencode/agent.ts
+++ b/src/lib/opencode/agent.ts
@@ -34,7 +34,7 @@ type OpencodeServer = Awaited<ReturnType<typeof createOpencodeServer>>;
 
 type OpencodeAcpAgentOptions = {
   model?: string;
-  modelOptions?: Record<string, unknown>;
+  modelOptions?: Record<string, string>;
 };
 
 class OpencodeAcpAgent implements Agent {
@@ -393,12 +393,12 @@ function parseModelID(model: string): { providerID: string; modelID: string } {
   };
 }
 
-function parseModelOptions(entries: string[]): Record<string, unknown> | undefined {
+function parseModelOptions(entries: string[]): Record<string, string> | undefined {
   if (entries.length === 0) {
     return undefined;
   }
 
-  const options: Record<string, unknown> = {};
+  const options: Record<string, string> = {};
   for (const entry of entries) {
     const separatorIndex = entry.indexOf("=");
     if (separatorIndex <= 0) {
@@ -410,55 +410,10 @@ function parseModelOptions(entries: string[]): Record<string, unknown> | undefin
       throw new Error(`Invalid --model-option "${entry}". Expected key=value.`);
     }
 
-    setModelOption(options, key, parseModelOptionValue(entry.slice(separatorIndex + 1)));
+    options[key] = entry.slice(separatorIndex + 1);
   }
 
   return options;
-}
-
-function setModelOption(target: Record<string, unknown>, key: string, value: unknown): void {
-  const path = key.split(".");
-  let cursor = target;
-  for (const [index, part] of path.entries()) {
-    if (!part) {
-      throw new Error(`Invalid --model-option key "${key}". Empty path segment.`);
-    }
-
-    if (index === path.length - 1) {
-      cursor[part] = value;
-      return;
-    }
-
-    const next = cursor[part];
-    if (!isRecord(next)) {
-      cursor[part] = {};
-    }
-    cursor = cursor[part] as Record<string, unknown>;
-  }
-}
-
-function parseModelOptionValue(value: string): unknown {
-  const trimmed = value.trim();
-  if (trimmed === "true") {
-    return true;
-  }
-  if (trimmed === "false") {
-    return false;
-  }
-  if (/^-?(?:0|[1-9]\d*)(?:\.\d+)?$/.test(trimmed)) {
-    return Number(trimmed);
-  }
-  if (
-    (trimmed.startsWith("{") && trimmed.endsWith("}")) ||
-    (trimmed.startsWith("[") && trimmed.endsWith("]"))
-  ) {
-    return JSON.parse(trimmed);
-  }
-  return value;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 const TOOL_KIND_BY_NAME: Record<string, ToolKind> = {
@@ -529,7 +484,7 @@ Usage: acpella-opencode-acp [--model <provider/model>] [--model-option <key=valu
 
 Options:
   --model <provider/model>     Model to use. Example: "openai/gpt-5.5". You can list by running "opencode models".
-  --model-option <key=value>   Per-model OpenCode option for the selected model. Repeatable. Dotted keys create nested objects.
+  --model-option <key=value>   Per-model OpenCode string option for the selected model. Repeatable.
   --help                       Show this help
 `);
     return;

--- a/src/lib/opencode/agent.ts
+++ b/src/lib/opencode/agent.ts
@@ -451,11 +451,10 @@ Options:
     if (!modelParts) {
       throw new Error("--model-option requires --model in <provider/model> format");
     }
-    const [providerID, modelID] = modelParts;
     config.provider = {
-      [providerID]: {
+      [modelParts[0]]: {
         models: {
-          [modelID]: {
+          [modelParts[1]]: {
             options,
           },
         },

--- a/src/lib/opencode/agent.ts
+++ b/src/lib/opencode/agent.ts
@@ -30,6 +30,7 @@ import {
   type ServerOptions,
   type ToolPart,
 } from "@opencode-ai/sdk/v2";
+import { splitOnce } from "../../utils/index.ts";
 
 type OpencodeServer = Awaited<ReturnType<typeof createOpencodeServer>>;
 
@@ -351,14 +352,6 @@ async function getModel(
   return provider?.models[options.modelID];
 }
 
-function splitOnce(value: string, separator: string): [string, string] | undefined {
-  const separatorIndex = value.indexOf(separator);
-  if (separatorIndex < 0) {
-    return undefined;
-  }
-  return [value.slice(0, separatorIndex), value.slice(separatorIndex + separator.length)];
-}
-
 const TOOL_KIND_BY_NAME: Record<string, ToolKind> = {
   bash: "execute",
   glob: "search",
@@ -448,15 +441,14 @@ Options:
     }
     const options: Record<string, string> = {};
     for (const entry of modelOptionArgs) {
-      const parts = splitOnce(entry, "=");
-      const key = parts?.[0].trim();
-      if (!parts || !key) {
+      const kv = splitOnce(entry, "=");
+      if (!kv) {
         throw new Error(`Invalid --model-option "${entry}". Expected key=value.`);
       }
-      options[key] = parts[1];
+      options[kv[0]] = kv[1];
     }
     const modelParts = splitOnce(model, "/");
-    if (!modelParts || !modelParts[0] || !modelParts[1]) {
+    if (!modelParts) {
       throw new Error("--model-option requires --model in <provider/model> format");
     }
     const [providerID, modelID] = modelParts;

--- a/src/lib/opencode/agent.ts
+++ b/src/lib/opencode/agent.ts
@@ -436,9 +436,6 @@ Options:
 
   const modelOptionArgs = parsed.values["model-option"] ?? [];
   if (modelOptionArgs.length > 0) {
-    if (!model) {
-      throw new Error("--model-option requires --model");
-    }
     const options: Record<string, string> = {};
     for (const entry of modelOptionArgs) {
       const kv = splitOnce(entry, "=");
@@ -446,6 +443,9 @@ Options:
         throw new Error(`Invalid --model-option "${entry}". Expected key=value.`);
       }
       options[kv[0]] = kv[1];
+    }
+    if (!model) {
+      throw new Error("--model-option requires --model");
     }
     const modelParts = splitOnce(model, "/");
     if (!modelParts) {

--- a/src/lib/opencode/agent.ts
+++ b/src/lib/opencode/agent.ts
@@ -34,6 +34,7 @@ type OpencodeServer = Awaited<ReturnType<typeof createOpencodeServer>>;
 
 type OpencodeAcpAgentOptions = {
   model?: string;
+  modelOptions?: Record<string, unknown>;
 };
 
 class OpencodeAcpAgent implements Agent {
@@ -52,12 +53,7 @@ class OpencodeAcpAgent implements Agent {
     this.server ??= await createOpencodeServer({
       port: 0,
       timeout: 10000,
-      config: {
-        model: this.options.model,
-        permission: {
-          question: "deny",
-        },
-      },
+      config: createOpencodeConfig(this.options),
     });
     return this.server;
   }
@@ -359,6 +355,112 @@ async function getModel(
   return provider?.models[options.modelID];
 }
 
+function createOpencodeConfig(options: OpencodeAcpAgentOptions) {
+  const config: NonNullable<Parameters<typeof createOpencodeServer>[0]>["config"] = {
+    model: options.model,
+    permission: {
+      question: "deny",
+    },
+  };
+
+  if (options.modelOptions && Object.keys(options.modelOptions).length > 0) {
+    if (!options.model) {
+      throw new Error("--model-option requires --model <provider/model>");
+    }
+    const parsedModel = parseModelID(options.model);
+    config.provider = {
+      [parsedModel.providerID]: {
+        models: {
+          [parsedModel.modelID]: {
+            options: options.modelOptions,
+          },
+        },
+      },
+    };
+  }
+
+  return config;
+}
+
+function parseModelID(model: string): { providerID: string; modelID: string } {
+  const separatorIndex = model.indexOf("/");
+  if (separatorIndex <= 0 || separatorIndex === model.length - 1) {
+    throw new Error("--model-option requires --model in <provider/model> format");
+  }
+  return {
+    providerID: model.slice(0, separatorIndex),
+    modelID: model.slice(separatorIndex + 1),
+  };
+}
+
+function parseModelOptions(entries: string[]): Record<string, unknown> | undefined {
+  if (entries.length === 0) {
+    return undefined;
+  }
+
+  const options: Record<string, unknown> = {};
+  for (const entry of entries) {
+    const separatorIndex = entry.indexOf("=");
+    if (separatorIndex <= 0) {
+      throw new Error(`Invalid --model-option "${entry}". Expected key=value.`);
+    }
+
+    const key = entry.slice(0, separatorIndex).trim();
+    if (!key) {
+      throw new Error(`Invalid --model-option "${entry}". Expected key=value.`);
+    }
+
+    setModelOption(options, key, parseModelOptionValue(entry.slice(separatorIndex + 1)));
+  }
+
+  return options;
+}
+
+function setModelOption(target: Record<string, unknown>, key: string, value: unknown): void {
+  const path = key.split(".");
+  let cursor = target;
+  for (const [index, part] of path.entries()) {
+    if (!part) {
+      throw new Error(`Invalid --model-option key "${key}". Empty path segment.`);
+    }
+
+    if (index === path.length - 1) {
+      cursor[part] = value;
+      return;
+    }
+
+    const next = cursor[part];
+    if (!isRecord(next)) {
+      cursor[part] = {};
+    }
+    cursor = cursor[part] as Record<string, unknown>;
+  }
+}
+
+function parseModelOptionValue(value: string): unknown {
+  const trimmed = value.trim();
+  if (trimmed === "true") {
+    return true;
+  }
+  if (trimmed === "false") {
+    return false;
+  }
+  if (/^-?(?:0|[1-9]\d*)(?:\.\d+)?$/.test(trimmed)) {
+    return Number(trimmed);
+  }
+  if (
+    (trimmed.startsWith("{") && trimmed.endsWith("}")) ||
+    (trimmed.startsWith("[") && trimmed.endsWith("]"))
+  ) {
+    return JSON.parse(trimmed);
+  }
+  return value;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 const TOOL_KIND_BY_NAME: Record<string, ToolKind> = {
   bash: "execute",
   glob: "search",
@@ -416,20 +518,27 @@ function main() {
     options: {
       help: { type: "boolean" },
       model: { type: "string" },
+      "model-option": { type: "string", multiple: true },
     },
     strict: true,
     allowPositionals: false,
   });
   if (parsed.values.help) {
     console.log(`\
-Usage: acpella-opencode-acp [--model <provider/model>]
+Usage: acpella-opencode-acp [--model <provider/model>] [--model-option <key=value>...]
 
 Options:
-  --model <provider/model>  Model to use. Example: "openai/gpt-5.5". You can list by running "opencode models".
-  --help                    Show this help
+  --model <provider/model>     Model to use. Example: "openai/gpt-5.5". You can list by running "opencode models".
+  --model-option <key=value>   Per-model OpenCode option for the selected model. Repeatable. Dotted keys create nested objects.
+  --help                       Show this help
 `);
     return;
   }
+
+  const options: OpencodeAcpAgentOptions = {
+    model: parsed.values.model,
+    modelOptions: parseModelOptions(parsed.values["model-option"] ?? []),
+  };
 
   const input = Writable.toWeb(process.stdout);
   const output = Readable.toWeb(process.stdin) as ReadableStream<Uint8Array>;
@@ -437,7 +546,7 @@ Options:
 
   let agent: OpencodeAcpAgent;
   const connection = new AgentSideConnection((connection) => {
-    agent = new OpencodeAcpAgent(connection, parsed.values);
+    agent = new OpencodeAcpAgent(connection, options);
     return agent;
   }, stream);
 

--- a/src/lib/opencode/agent.ts
+++ b/src/lib/opencode/agent.ts
@@ -393,29 +393,6 @@ function parseModelID(model: string): { providerID: string; modelID: string } {
   };
 }
 
-function parseModelOptions(entries: string[]): Record<string, string> | undefined {
-  if (entries.length === 0) {
-    return undefined;
-  }
-
-  const options: Record<string, string> = {};
-  for (const entry of entries) {
-    const separatorIndex = entry.indexOf("=");
-    if (separatorIndex <= 0) {
-      throw new Error(`Invalid --model-option "${entry}". Expected key=value.`);
-    }
-
-    const key = entry.slice(0, separatorIndex).trim();
-    if (!key) {
-      throw new Error(`Invalid --model-option "${entry}". Expected key=value.`);
-    }
-
-    options[key] = entry.slice(separatorIndex + 1);
-  }
-
-  return options;
-}
-
 const TOOL_KIND_BY_NAME: Record<string, ToolKind> = {
   bash: "execute",
   glob: "search",
@@ -490,9 +467,19 @@ Options:
     return;
   }
 
+  const modelOptionEntries = parsed.values["model-option"] ?? [];
   const options: OpencodeAcpAgentOptions = {
     model: parsed.values.model,
-    modelOptions: parseModelOptions(parsed.values["model-option"] ?? []),
+    modelOptions: Object.fromEntries(
+      modelOptionEntries.map((entry) => {
+        const separatorIndex = entry.indexOf("=");
+        const key = entry.slice(0, separatorIndex).trim();
+        if (separatorIndex <= 0 || !key) {
+          throw new Error(`Invalid --model-option "${entry}". Expected key=value.`);
+        }
+        return [key, entry.slice(separatorIndex + 1)];
+      }),
+    ),
   };
 
   const input = Writable.toWeb(process.stdout);

--- a/src/lib/opencode/agent.ts
+++ b/src/lib/opencode/agent.ts
@@ -436,13 +436,7 @@ Options:
     return;
   }
 
-  const modelOptionEntries = parsed.values["model-option"] ?? [];
   const model = parsed.values.model;
-  if (modelOptionEntries.length > 0 && !model) {
-    throw new Error("--model-option requires --model <provider/model>");
-  }
-  const parsedModel = modelOptionEntries.length > 0 ? parseModelID(model!) : undefined;
-
   const config: ServerOptions["config"] = {
     model,
     permission: {
@@ -450,21 +444,26 @@ Options:
     },
   };
 
-  if (modelOptionEntries.length > 0 && parsedModel) {
+  const modelOptionArgs = parsed.values["model-option"] ?? [];
+  if (modelOptionArgs.length > 0) {
+    if (!model) {
+      throw new Error("--model-option requires --model");
+    }
+    const options: Record<string, string> = {};
+    for (const entry of modelOptionArgs) {
+      const separatorIndex = entry.indexOf("=");
+      const key = entry.slice(0, separatorIndex).trim();
+      if (separatorIndex <= 0 || !key) {
+        throw new Error(`Invalid --model-option "${entry}". Expected key=value.`);
+      }
+      options[key] = entry.slice(separatorIndex + 1);
+    }
+    const { providerID, modelID } = parseModelID(model);
     config.provider = {
-      [parsedModel.providerID]: {
+      [providerID]: {
         models: {
-          [parsedModel.modelID]: {
-            options: Object.fromEntries(
-              modelOptionEntries.map((entry) => {
-                const separatorIndex = entry.indexOf("=");
-                const key = entry.slice(0, separatorIndex).trim();
-                if (separatorIndex <= 0 || !key) {
-                  throw new Error(`Invalid --model-option "${entry}". Expected key=value.`);
-                }
-                return [key, entry.slice(separatorIndex + 1)];
-              }),
-            ),
+          [modelID]: {
+            options,
           },
         },
       },

--- a/src/lib/opencode/agent.ts
+++ b/src/lib/opencode/agent.ts
@@ -351,15 +351,12 @@ async function getModel(
   return provider?.models[options.modelID];
 }
 
-function parseModelID(model: string): { providerID: string; modelID: string } {
-  const separatorIndex = model.indexOf("/");
-  if (separatorIndex <= 0 || separatorIndex === model.length - 1) {
-    throw new Error("--model-option requires --model in <provider/model> format");
+function splitOnce(value: string, separator: string): [string, string] | undefined {
+  const separatorIndex = value.indexOf(separator);
+  if (separatorIndex < 0) {
+    return undefined;
   }
-  return {
-    providerID: model.slice(0, separatorIndex),
-    modelID: model.slice(separatorIndex + 1),
-  };
+  return [value.slice(0, separatorIndex), value.slice(separatorIndex + separator.length)];
 }
 
 const TOOL_KIND_BY_NAME: Record<string, ToolKind> = {
@@ -451,14 +448,18 @@ Options:
     }
     const options: Record<string, string> = {};
     for (const entry of modelOptionArgs) {
-      const separatorIndex = entry.indexOf("=");
-      const key = entry.slice(0, separatorIndex).trim();
-      if (separatorIndex <= 0 || !key) {
+      const parts = splitOnce(entry, "=");
+      const key = parts?.[0].trim();
+      if (!parts || !key) {
         throw new Error(`Invalid --model-option "${entry}". Expected key=value.`);
       }
-      options[key] = entry.slice(separatorIndex + 1);
+      options[key] = parts[1];
     }
-    const { providerID, modelID } = parseModelID(model);
+    const modelParts = splitOnce(model, "/");
+    if (!modelParts || !modelParts[0] || !modelParts[1]) {
+      throw new Error("--model-option requires --model in <provider/model> format");
+    }
+    const [providerID, modelID] = modelParts;
     config.provider = {
       [providerID]: {
         models: {

--- a/src/lib/opencode/agent.ts
+++ b/src/lib/opencode/agent.ts
@@ -27,6 +27,7 @@ import {
   type Part,
   type Session,
   type SessionPromptResponse,
+  type ServerOptions,
   type ToolPart,
 } from "@opencode-ai/sdk/v2";
 
@@ -356,7 +357,7 @@ async function getModel(
 }
 
 function createOpencodeConfig(options: OpencodeAcpAgentOptions) {
-  const config: NonNullable<Parameters<typeof createOpencodeServer>[0]>["config"] = {
+  const config: ServerOptions["config"] = {
     model: options.model,
     permission: {
       question: "deny",

--- a/src/lib/opencode/agent.ts
+++ b/src/lib/opencode/agent.ts
@@ -33,18 +33,13 @@ import {
 
 type OpencodeServer = Awaited<ReturnType<typeof createOpencodeServer>>;
 
-type OpencodeAcpAgentOptions = {
-  model?: string;
-  modelOptions?: Record<string, string>;
-};
-
 class OpencodeAcpAgent implements Agent {
   private server?: OpencodeServer;
   private sessions = new Map<string, Session>();
 
   constructor(
     private connection: AgentSideConnection,
-    private options: OpencodeAcpAgentOptions,
+    private config: ServerOptions["config"],
   ) {}
 
   private async getServer(): Promise<OpencodeServer> {
@@ -54,7 +49,7 @@ class OpencodeAcpAgent implements Agent {
     this.server ??= await createOpencodeServer({
       port: 0,
       timeout: 10000,
-      config: createOpencodeConfig(this.options),
+      config: this.config,
     });
     return this.server;
   }
@@ -356,33 +351,6 @@ async function getModel(
   return provider?.models[options.modelID];
 }
 
-function createOpencodeConfig(options: OpencodeAcpAgentOptions) {
-  const config: ServerOptions["config"] = {
-    model: options.model,
-    permission: {
-      question: "deny",
-    },
-  };
-
-  if (options.modelOptions && Object.keys(options.modelOptions).length > 0) {
-    if (!options.model) {
-      throw new Error("--model-option requires --model <provider/model>");
-    }
-    const parsedModel = parseModelID(options.model);
-    config.provider = {
-      [parsedModel.providerID]: {
-        models: {
-          [parsedModel.modelID]: {
-            options: options.modelOptions,
-          },
-        },
-      },
-    };
-  }
-
-  return config;
-}
-
 function parseModelID(model: string): { providerID: string; modelID: string } {
   const separatorIndex = model.indexOf("/");
   if (separatorIndex <= 0 || separatorIndex === model.length - 1) {
@@ -469,19 +437,39 @@ Options:
   }
 
   const modelOptionEntries = parsed.values["model-option"] ?? [];
-  const options: OpencodeAcpAgentOptions = {
-    model: parsed.values.model,
-    modelOptions: Object.fromEntries(
-      modelOptionEntries.map((entry) => {
-        const separatorIndex = entry.indexOf("=");
-        const key = entry.slice(0, separatorIndex).trim();
-        if (separatorIndex <= 0 || !key) {
-          throw new Error(`Invalid --model-option "${entry}". Expected key=value.`);
-        }
-        return [key, entry.slice(separatorIndex + 1)];
-      }),
-    ),
+  const model = parsed.values.model;
+  if (modelOptionEntries.length > 0 && !model) {
+    throw new Error("--model-option requires --model <provider/model>");
+  }
+  const parsedModel = modelOptionEntries.length > 0 ? parseModelID(model!) : undefined;
+
+  const config: ServerOptions["config"] = {
+    model,
+    permission: {
+      question: "deny",
+    },
   };
+
+  if (modelOptionEntries.length > 0 && parsedModel) {
+    config.provider = {
+      [parsedModel.providerID]: {
+        models: {
+          [parsedModel.modelID]: {
+            options: Object.fromEntries(
+              modelOptionEntries.map((entry) => {
+                const separatorIndex = entry.indexOf("=");
+                const key = entry.slice(0, separatorIndex).trim();
+                if (separatorIndex <= 0 || !key) {
+                  throw new Error(`Invalid --model-option "${entry}". Expected key=value.`);
+                }
+                return [key, entry.slice(separatorIndex + 1)];
+              }),
+            ),
+          },
+        },
+      },
+    };
+  }
 
   const input = Writable.toWeb(process.stdout);
   const output = Readable.toWeb(process.stdin) as ReadableStream<Uint8Array>;
@@ -489,7 +477,7 @@ Options:
 
   let agent: OpencodeAcpAgent;
   const connection = new AgentSideConnection((connection) => {
-    agent = new OpencodeAcpAgent(connection, options);
+    agent = new OpencodeAcpAgent(connection, config);
     return agent;
   }, stream);
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -12,6 +12,13 @@ export function addIndent({ text, indent }: { text: string; indent: string }): s
     .join("\n");
 }
 
+export function splitOnce(value: string, sep: string): [string, string] | undefined {
+  const i = value.indexOf(sep);
+  if (i >= 0) {
+    return [value.slice(0, i), value.slice(i + sep.length)];
+  }
+}
+
 export function objectPickBy<K extends PropertyKey, V>(
   o: Record<K, V>,
   f: (v: V, k: K) => boolean,


### PR DESCRIPTION
## Summary
- add repeatable `--model-option key=value` support to the local OpenCode ACP adapter
- map options into OpenCode per-model provider config for the selected `--model`
- document reasoning/thinking option examples for OpenCode registration

## Verification
- `pnpm lint`