### PR TITLE
fix: support git install

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,28 +6,9 @@ Thin service that connects a messaging channel (Telegram) to AI agent via [ACP](
 
 ```bash
 npm install -g github:hi-ogawa/acpella
-
-mkdir -p ~/.config/acpella
-${EDITOR:-vi} ~/.config/acpella/.env
-
-acpella repl
-acpella exec /status
 ```
 
-Set the required values from the Config section below. For deployment, systemd, agent registration, cron, and troubleshooting workflows, see [`skills/acpella`](skills/acpella/SKILL.md).
-
-## Config
-
-| Variable                            | Default         | Description                                |
-| ----------------------------------- | --------------- | ------------------------------------------ |
-| `ACPELLA_TELEGRAM_BOT_TOKEN`        | —               | Bot token from @BotFather                  |
-| `ACPELLA_TELEGRAM_ALLOWED_USER_IDS` | —               | Comma-separated numeric Telegram user IDs  |
-| `ACPELLA_TELEGRAM_ALLOWED_CHAT_IDS` | —               | Comma-separated chat IDs (group allowlist) |
-| `ACPELLA_HOME`                      | `process.cwd()` | Agent working directory                    |
-
-## Configuring Agent
-
-The default agent is the built-in `test` echo agent. See [skills/acpella](skills/acpella/SKILL.md) for current agent registration, session, customization, cron, and service administration workflows.
+See [`skills/acpella`](skills/acpella/SKILL.md) for setup, configuration, deployment, agent registration, systemd, cron, and troubleshooting workflows.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Test locally on checkout source
 
 ```sh
 pnpm install
+pnpm vp config
 
 # run with .env.dev
 pnpm dev repl

--- a/README.md
+++ b/README.md
@@ -5,14 +5,11 @@ Thin service that connects a messaging channel (Telegram) to AI agent via [ACP](
 ## Setup
 
 ```bash
-pnpm install
+npm install -g github:hi-ogawa/acpella
 
-# Make `acpella` cli available globally
-pnpm link --global
-
-# Edit .env using the Config section below
+# Create .env using the Config section below
 mkdir -p ~/.config/acpella
-cp .env.example ~/.config/acpella/.env
+${EDITOR:-vi} ~/.config/acpella/.env
 
 acpella serve        # run Telegram bot service
 acpella repl         # run REPL
@@ -39,6 +36,9 @@ Test locally on checkout source
 ```sh
 pnpm install
 pnpm vp config
+
+# optionally make this checkout available as the global CLI while developing
+pnpm link --global
 
 # run with .env.dev
 pnpm dev repl

--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ Thin service that connects a messaging channel (Telegram) to AI agent via [ACP](
 ```bash
 npm install -g github:hi-ogawa/acpella
 
-# Create .env using the Config section below
 mkdir -p ~/.config/acpella
 ${EDITOR:-vi} ~/.config/acpella/.env
 
-acpella serve        # run Telegram bot service
-acpella repl         # run REPL
-acpella exec /status # run one local admin command
+acpella repl
+acpella exec /status
 ```
+
+Set the required values from the Config section below. For deployment, systemd, agent registration, cron, and troubleshooting workflows, see [`skills/acpella`](skills/acpella/SKILL.md).
 
 ## Config
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "acpella",
+  "version": "0.0.0",
   "private": true,
   "bin": {
     "acpella": "./src/bin/cli.js",
@@ -12,7 +13,6 @@
     "#test-agent": "./src/bin/test-agent.js"
   },
   "scripts": {
-    "prepare": "vp config",
     "cli": "node ./src/bin/cli.js",
     "dev": "node ./src/bin/cli.js --env-file=.env.dev",
     "test": "vitest --project=unit",

--- a/skills/acpella/SKILL.md
+++ b/skills/acpella/SKILL.md
@@ -14,7 +14,7 @@ Acpella is a small bridge from a messaging surface, currently Telegram, Discord,
 ## Working model
 
 - Acpella source lives at https://github.com/hi-ogawa/acpella.
-- The normal operator CLI is the globally linked `acpella` command, installed from the source checkout with `pnpm link --global`.
+- The normal operator CLI is the globally installed `acpella` command, usually installed with `npm install -g github:hi-ogawa/acpella`.
 - `ACPELLA_HOME` is the working directory acpella uses for agent sessions and acpella state.
 - Acpella stores its own state under `ACPELLA_HOME/.acpella/`, including session mappings, configured agents, cron jobs, logs, and optional custom instructions.
 - A Telegram chat/thread, Discord channel, or REPL context maps to an acpella session name.
@@ -45,7 +45,7 @@ Commands that control process-local runtime state, such as `/cron start`, `/cron
 
 Use `acpella exec <slash-command...>` only for local shell administration of acpella itself: inspecting or changing installation-wide state, listing configured objects, or running setup commands.
 
-Command examples use `acpella`, which assumes the global CLI is linked to the checkout/version that owns the running service. If it is not, run `pnpm link --global` from the intended checkout or use that installation's equivalent acpella CLI entrypoint.
+Command examples use `acpella`, which assumes the global CLI is the installation/version that owns the running service. For deployment, install or update it with `npm install -g github:hi-ogawa/acpella`. For source checkout development, use `pnpm link --global`.
 
 Good `exec` examples:
 

--- a/skills/acpella/references/bootstrap.md
+++ b/skills/acpella/references/bootstrap.md
@@ -4,18 +4,25 @@ Use this reference for first-time setup and initial local runs of acpella.
 
 ## Basic setup
 
-Clone the source from https://github.com/hi-ogawa/acpella:
+Install acpella globally from GitHub:
+
+```bash
+npm install -g github:hi-ogawa/acpella
+mkdir -p ~/.config/acpella
+${EDITOR:-vi} ~/.config/acpella/.env
+```
+
+After creating `.env`, set the main config values below.
+
+For source checkout development:
 
 ```bash
 git clone https://github.com/hi-ogawa/acpella
 cd acpella
 pnpm install
+pnpm vp config
 pnpm link --global
-mkdir -p ~/.config/acpella
-cp .env.example ~/.config/acpella/.env
 ```
-
-After copying `.env`, edit the main config values below.
 
 ## Config
 
@@ -39,7 +46,7 @@ Notes:
 
 ## First local runs
 
-Run these after linking the global CLI from the acpella source checkout.
+Run these after installing the global CLI.
 
 Run the Telegram bot:
 

--- a/skills/acpella/references/bootstrap.md
+++ b/skills/acpella/references/bootstrap.md
@@ -14,16 +14,6 @@ ${EDITOR:-vi} ~/.config/acpella/.env
 
 After creating `.env`, set the main config values below.
 
-For source checkout development:
-
-```bash
-git clone https://github.com/hi-ogawa/acpella
-cd acpella
-pnpm install
-pnpm vp config
-pnpm link --global
-```
-
 ## Config
 
 | Variable                              | Default         | Description                                  |

--- a/skills/acpella/references/systemd.md
+++ b/skills/acpella/references/systemd.md
@@ -4,13 +4,13 @@ Use this reference for installing acpella as a user service, updating the unit, 
 
 ## Generate the user unit
 
-Use the global `acpella` CLI linked to the checkout/version you want the service to run:
+Use the global `acpella` CLI installed with the version you want the service to run:
 
 ```bash
 acpella exec /service systemd install
 ```
 
-This writes a user unit for the linked acpella installation. Prefer running this from a local shell through `exec`; it is a host administration side effect.
+This writes a user unit for the current acpella installation. Prefer running this from a local shell through `exec`; it is a host administration side effect.
 
 ## First install
 
@@ -56,6 +56,21 @@ Treat this as a host power-policy choice, not acpella configuration.
 ## After updating the unit
 
 ```bash
+systemctl --user daemon-reload
+systemctl --user restart acpella
+```
+
+## After updating acpella
+
+```bash
+npm install -g github:hi-ogawa/acpella
+systemctl --user restart acpella
+```
+
+If the Node or npm global prefix changed, regenerate the unit before restarting:
+
+```bash
+acpella exec /service systemd install
 systemctl --user daemon-reload
 systemctl --user restart acpella
 ```

--- a/skills/acpella/references/troubleshooting.md
+++ b/skills/acpella/references/troubleshooting.md
@@ -47,7 +47,7 @@ acpella exec /status
 acpella exec /agent list
 ```
 
-Run these through the global `acpella` CLI linked to the checkout/version that owns the running service, not from `ACPELLA_HOME` unless they are the same directory.
+Run these through the global `acpella` CLI installation/version that owns the running service, not from `ACPELLA_HOME` unless they are the same directory.
 
 ## Prompt customization not taking effect
 
@@ -86,7 +86,7 @@ acpella exec /cron status
 acpella exec /cron list
 ```
 
-Run these through the global `acpella` CLI linked to the checkout/version that owns the running service, not from `ACPELLA_HOME` unless they are the same directory.
+Run these through the global `acpella` CLI installation/version that owns the running service, not from `ACPELLA_HOME` unless they are the same directory.
 
 ## When deeper inspection is needed
 


### PR DESCRIPTION
## Summary
- remove the npm `prepare` lifecycle hook so Git installs do not run dev setup during dependency preparation
- add a package version so npm can pack the repo
- document `npm install -g github:hi-ogawa/acpella` as the deployment install path
- keep README setup minimal and direct operational setup/config/deployment details to `skills/acpella`
- keep `pnpm vp config` and `pnpm link --global` scoped to source checkout development

## Verification
- `npm pack --dry-run --json`