### PR TITLE
feat: serve configured channels together

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # acpella
 
-Thin service that connects a messaging channel (Telegram) to AI agent via [ACP](https://github.com/agentclientprotocol/agent-client-protocol). Agent-agnostic — works with [OpenCode](https://github.com/anomalyco/opencode), [Codex](https://github.com/zed-industries/codex-acp/), or any [ACP-compatible agent](https://agentclientprotocol.com/get-started/agents).
+Thin service that connects messaging channels such as Telegram and Discord to AI agents via [ACP](https://github.com/agentclientprotocol/agent-client-protocol). Agent-agnostic — works with [OpenCode](https://github.com/anomalyco/opencode), [Codex](https://github.com/zed-industries/codex-acp/), or any [ACP-compatible agent](https://agentclientprotocol.com/get-started/agents).
 
 ## Setup
 

--- a/skills/acpella/SKILL.md
+++ b/skills/acpella/SKILL.md
@@ -33,7 +33,7 @@ When unsure which slash command or arguments to use, start with `/help` from Tel
 ## Command process scope
 
 - Telegram commands are handled by the long-running acpella bot service.
-- Discord commands are handled by the long-running acpella bot service when served with `--channel=discord`.
+- Discord commands are handled by the long-running acpella bot service.
 - REPL commands are handled by that REPL process.
 - `acpella exec <slash-command...>` starts a separate short-lived acpella process, handles one command, then exits.
 

--- a/skills/acpella/references/bootstrap.md
+++ b/skills/acpella/references/bootstrap.md
@@ -38,23 +38,10 @@ Notes:
 
 Run these after installing the global CLI.
 
-Run the Telegram bot:
+Run the configured bot service. If both Telegram and Discord are configured, this starts both channels from one process:
 
 ```bash
 acpella serve
-```
-
-Run the Discord bot:
-
-```bash
-acpella serve --channel=discord
-```
-
-When running Telegram and Discord as separate service processes, run cron in only one of them:
-
-```bash
-acpella serve --channel=telegram
-acpella serve --channel=discord --no-cron
 ```
 
 Run the local REPL:

--- a/skills/acpella/references/bootstrap.md
+++ b/skills/acpella/references/bootstrap.md
@@ -30,6 +30,7 @@ After creating `.env`, set the main config values below.
 Notes:
 
 - Telegram and Discord configuration are not required for `acpella repl`.
+- `acpella serve` enables each channel based on its bot token. Set `ACPELLA_TELEGRAM_BOT_TOKEN` to enable Telegram, `ACPELLA_DISCORD_BOT_TOKEN` to enable Discord, or set both tokens to run both channels from the same service process.
 - For Telegram setup details, see [channels/telegram.md](channels/telegram.md).
 - For Discord setup details, see [channels/discord.md](channels/discord.md).
 - If `ACPELLA_HOME/.acpella/AGENTS.md` exists, acpella sends it as custom instructions once when creating a new session.
@@ -38,7 +39,7 @@ Notes:
 
 Run these after installing the global CLI.
 
-Run the configured bot service. If both Telegram and Discord are configured, this starts both channels from one process:
+Run the configured bot service. A single `acpella serve` process can serve Telegram, Discord, or both, depending on which bot tokens are configured:
 
 ```bash
 acpella serve

--- a/skills/acpella/references/channels/discord.md
+++ b/skills/acpella/references/channels/discord.md
@@ -40,12 +40,5 @@ ACPELLA_DISCORD_ALLOWED_CHANNEL_IDS=123456789012345678
 ## Run
 
 ```bash
-acpella serve --channel=discord
-```
-
-When dogfooding Telegram and Discord as separate service processes, let only one process run cron:
-
-```bash
-acpella serve --channel=telegram
-acpella serve --channel=discord --no-cron
+acpella serve
 ```

--- a/skills/acpella/references/channels/discord.md
+++ b/skills/acpella/references/channels/discord.md
@@ -39,6 +39,8 @@ ACPELLA_DISCORD_ALLOWED_CHANNEL_IDS=123456789012345678
 
 ## Run
 
+Discord is enabled for `acpella serve` when `ACPELLA_DISCORD_BOT_TOKEN` is set.
+
 ```bash
 acpella serve
 ```

--- a/skills/acpella/references/channels/telegram.md
+++ b/skills/acpella/references/channels/telegram.md
@@ -40,5 +40,3 @@ Telegram is enabled for `acpella serve` when `ACPELLA_TELEGRAM_BOT_TOKEN` is set
 ```bash
 acpella serve
 ```
-
-If Discord's bot token is also configured, the same process starts both channels.

--- a/skills/acpella/references/channels/telegram.md
+++ b/skills/acpella/references/channels/telegram.md
@@ -1,6 +1,6 @@
 # Telegram Channel
 
-Use this reference for a lightweight Telegram setup for `acpella serve --channel=telegram`.
+Use this reference for a lightweight Telegram setup for `acpella serve`.
 
 ## Telegram Bot
 
@@ -39,4 +39,4 @@ ACPELLA_TELEGRAM_ALLOWED_CHAT_IDS=123456789
 acpella serve
 ```
 
-Telegram is the default channel. `acpella serve --channel=telegram` is equivalent.
+If Discord is also configured, the same process starts both channels.

--- a/skills/acpella/references/channels/telegram.md
+++ b/skills/acpella/references/channels/telegram.md
@@ -35,8 +35,10 @@ ACPELLA_TELEGRAM_ALLOWED_CHAT_IDS=123456789
 
 ## Run
 
+Telegram is enabled for `acpella serve` when `ACPELLA_TELEGRAM_BOT_TOKEN` is set.
+
 ```bash
 acpella serve
 ```
 
-If Discord is also configured, the same process starts both channels.
+If Discord's bot token is also configured, the same process starts both channels.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -139,12 +139,51 @@ ${CLI_HELP}`);
     return;
   }
 
-  const channelServices = await createConfiguredChannelServices({
-    config,
-    handler,
-    version,
-    registerCronDeliveryHandler,
-  });
+  const channelServices: ChannelService[] = [];
+  if (
+    Boolean(config.telegram.token) ||
+    config.telegram.allowedUserIds.length > 0 ||
+    config.telegram.allowedChatIds.length > 0
+  ) {
+    if (!config.telegram.token) {
+      throw new Error("ACPELLA_TELEGRAM_BOT_TOKEN is required");
+    }
+    if (config.telegram.allowedUserIds.length === 0) {
+      throw new Error("ACPELLA_TELEGRAM_ALLOWED_USER_IDS must be non-empty");
+    }
+    channelServices.push(
+      await createTelegramService({
+        config,
+        handler,
+        version,
+        registerCronDeliveryHandler,
+      }),
+    );
+  }
+  if (
+    Boolean(config.discord.token) ||
+    config.discord.allowedUserIds.length > 0 ||
+    config.discord.allowedGuildIds.length > 0 ||
+    config.discord.allowedChannelIds.length > 0
+  ) {
+    if (!config.discord.token) {
+      throw new Error("ACPELLA_DISCORD_BOT_TOKEN is required");
+    }
+    if (config.discord.allowedGuildIds.length === 0) {
+      throw new Error("ACPELLA_DISCORD_ALLOWED_GUILD_IDS must be non-empty");
+    }
+    channelServices.push(
+      await createDiscordService({
+        config,
+        handler,
+        version,
+        registerCronDeliveryHandler,
+      }),
+    );
+  }
+  if (channelServices.length === 0) {
+    throw new Error("No service channels configured. Configure Telegram or Discord credentials.");
+  }
   for (const service of channelServices) {
     cleanup.defer(() => service.stop());
   }
@@ -152,80 +191,6 @@ ${CLI_HELP}`);
   await Promise.all(channelServices.map((service) => service.start()));
   cronRunner.start();
   await Promise.all(channelServices.map((service) => service.wait()));
-}
-
-async function createConfiguredChannelServices(options: {
-  config: AppConfig;
-  handler: Handler;
-  version: string;
-  registerCronDeliveryHandler: (handler: CronDeliveryHandler) => void;
-}): Promise<ChannelService[]> {
-  const channels = resolveConfiguredChannels(options.config);
-  const services: ChannelService[] = [];
-  for (const channel of channels) {
-    switch (channel) {
-      case "telegram": {
-        services.push(await createTelegramService(options));
-        break;
-      }
-      case "discord": {
-        services.push(await createDiscordService(options));
-        break;
-      }
-    }
-  }
-  return services;
-}
-
-function resolveConfiguredChannels(config: AppConfig): ChannelName[] {
-  const channels: ChannelName[] = [];
-  if (hasAnyTelegramConfig(config)) {
-    validateTelegramConfig(config);
-    channels.push("telegram");
-  }
-  if (hasAnyDiscordConfig(config)) {
-    validateDiscordConfig(config);
-    channels.push("discord");
-  }
-  if (channels.length === 0) {
-    throw new Error("No service channels configured. Configure Telegram or Discord credentials.");
-  }
-  return channels;
-}
-
-function hasAnyTelegramConfig(config: AppConfig): boolean {
-  return (
-    Boolean(config.telegram.token) ||
-    config.telegram.allowedUserIds.length > 0 ||
-    config.telegram.allowedChatIds.length > 0
-  );
-}
-
-function validateTelegramConfig(config: AppConfig): void {
-  if (!config.telegram.token) {
-    throw new Error("ACPELLA_TELEGRAM_BOT_TOKEN is required");
-  }
-  if (config.telegram.allowedUserIds.length === 0) {
-    throw new Error("ACPELLA_TELEGRAM_ALLOWED_USER_IDS must be non-empty");
-  }
-}
-
-function hasAnyDiscordConfig(config: AppConfig): boolean {
-  return (
-    Boolean(config.discord.token) ||
-    config.discord.allowedUserIds.length > 0 ||
-    config.discord.allowedGuildIds.length > 0 ||
-    config.discord.allowedChannelIds.length > 0
-  );
-}
-
-function validateDiscordConfig(config: AppConfig): void {
-  if (!config.discord.token) {
-    throw new Error("ACPELLA_DISCORD_BOT_TOKEN is required");
-  }
-  if (config.discord.allowedGuildIds.length === 0) {
-    throw new Error("ACPELLA_DISCORD_ALLOWED_GUILD_IDS must be non-empty");
-  }
 }
 
 async function createTelegramService(options: {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,7 @@
 import "temporal-polyfill/global";
 import path from "node:path";
 import { createInterface } from "node:readline/promises";
-import { run } from "@grammyjs/runner";
+import { run, type RunnerHandle } from "@grammyjs/runner";
 import { Client, GatewayIntentBits, Partials, type Message } from "discord.js";
 import { Bot, type Context, type Filter } from "grammy";
 import { loadConfig, type AppConfig } from "./config.ts";
@@ -38,10 +38,16 @@ Commands:
 
 Options:
   --env-file=<path> Use this env file for config resolution.
-  --channel=<name>  Service channel for \`serve\` (telegram or discord, default: telegram).
-  --no-cron         Disable cron runner for this process.
   -h, --help        Show this help.
 `;
+
+type ChannelName = "telegram" | "discord";
+
+interface ChannelService {
+  start: () => Promise<void>;
+  wait: () => Promise<void>;
+  stop: () => Promise<void> | void;
+}
 
 async function main() {
   const cliArgv = process.argv.slice(2);
@@ -69,19 +75,6 @@ ${CLI_HELP}`);
 Missing message for exec
 
 ${CLI_HELP}`);
-  }
-
-  if (cli.channel && cli.command !== "serve") {
-    throw new Error(`--channel can only be used with serve`);
-  }
-  if (cli.noCron && cli.command !== "serve") {
-    throw new Error(`--no-cron can only be used with serve`);
-  }
-
-  // TODO: support serving multiple channels at once
-  const channel = cli.channel ?? "telegram";
-  if (cli.command === "serve" && !["telegram", "discord"].includes(channel)) {
-    throw new Error(`Invalid --channel: ${channel}`);
   }
 
   const config = loadConfig({
@@ -146,45 +139,109 @@ ${CLI_HELP}`);
     return;
   }
 
-  if (!cli.noCron) {
-    cronRunner.start();
+  const channelServices = await createConfiguredChannelServices({
+    config,
+    handler,
+    version,
+    registerCronDeliveryHandler,
+  });
+  for (const service of channelServices) {
+    cleanup.defer(() => service.stop());
   }
-  if (channel === "telegram") {
-    await serveTelegram({
-      config,
-      handler,
-      version,
-      registerCronDeliveryHandler,
-    });
-  }
-  if (channel === "discord") {
-    await serveDiscord({
-      config,
-      handler,
-      version,
-      registerCronDeliveryHandler,
-    });
-  }
+
+  await Promise.all(channelServices.map((service) => service.start()));
+  cronRunner.start();
+  await Promise.all(channelServices.map((service) => service.wait()));
 }
 
-async function serveTelegram(options: {
+async function createConfiguredChannelServices(options: {
   config: AppConfig;
   handler: Handler;
   version: string;
   registerCronDeliveryHandler: (handler: CronDeliveryHandler) => void;
-}) {
+}): Promise<ChannelService[]> {
+  const channels = resolveConfiguredChannels(options.config);
+  const services: ChannelService[] = [];
+  for (const channel of channels) {
+    switch (channel) {
+      case "telegram": {
+        services.push(await createTelegramService(options));
+        break;
+      }
+      case "discord": {
+        services.push(await createDiscordService(options));
+        break;
+      }
+    }
+  }
+  return services;
+}
+
+function resolveConfiguredChannels(config: AppConfig): ChannelName[] {
+  const channels: ChannelName[] = [];
+  if (hasAnyTelegramConfig(config)) {
+    validateTelegramConfig(config);
+    channels.push("telegram");
+  }
+  if (hasAnyDiscordConfig(config)) {
+    validateDiscordConfig(config);
+    channels.push("discord");
+  }
+  if (channels.length === 0) {
+    throw new Error("No service channels configured. Configure Telegram or Discord credentials.");
+  }
+  return channels;
+}
+
+function hasAnyTelegramConfig(config: AppConfig): boolean {
+  return (
+    Boolean(config.telegram.token) ||
+    config.telegram.allowedUserIds.length > 0 ||
+    config.telegram.allowedChatIds.length > 0
+  );
+}
+
+function validateTelegramConfig(config: AppConfig): void {
+  if (!config.telegram.token) {
+    throw new Error("ACPELLA_TELEGRAM_BOT_TOKEN is required");
+  }
+  if (config.telegram.allowedUserIds.length === 0) {
+    throw new Error("ACPELLA_TELEGRAM_ALLOWED_USER_IDS must be non-empty");
+  }
+}
+
+function hasAnyDiscordConfig(config: AppConfig): boolean {
+  return (
+    Boolean(config.discord.token) ||
+    config.discord.allowedUserIds.length > 0 ||
+    config.discord.allowedGuildIds.length > 0 ||
+    config.discord.allowedChannelIds.length > 0
+  );
+}
+
+function validateDiscordConfig(config: AppConfig): void {
+  if (!config.discord.token) {
+    throw new Error("ACPELLA_DISCORD_BOT_TOKEN is required");
+  }
+  if (config.discord.allowedGuildIds.length === 0) {
+    throw new Error("ACPELLA_DISCORD_ALLOWED_GUILD_IDS must be non-empty");
+  }
+}
+
+async function createTelegramService(options: {
+  config: AppConfig;
+  handler: Handler;
+  version: string;
+  registerCronDeliveryHandler: (handler: CronDeliveryHandler) => void;
+}): Promise<ChannelService> {
   const { config, handler, version, registerCronDeliveryHandler } = options;
   const allowedUsers = new Set(config.telegram.allowedUserIds);
   const allowedChats = new Set(config.telegram.allowedChatIds);
 
-  if (!config.telegram.token) {
+  const telegramToken = config.telegram.token;
+  if (!telegramToken) {
     throw new Error("ACPELLA_TELEGRAM_BOT_TOKEN is required");
   }
-  if (allowedUsers.size === 0) {
-    throw new Error("ACPELLA_TELEGRAM_ALLOWED_USER_IDS must be non-empty");
-  }
-
-  const telegramToken = config.telegram.token;
   const bot = new Bot(telegramToken);
   const botInfo = await bot.api.getMe();
   const botUsername = botInfo.username;
@@ -367,31 +424,35 @@ async function serveTelegram(options: {
     });
   });
 
-  console.log(`Starting service (version: ${version}, home: ${config.home}, channel: telegram)`);
-
-  const botRunner = run(bot, {
-    sink: {
-      // @grammyjs/runner defaults to 500; keep acpella conservative because prompts spawn child agents.
-      concurrency: 5,
+  let botRunner: RunnerHandle | undefined;
+  return {
+    start: async () => {
+      console.log(
+        `Starting service (version: ${version}, home: ${config.home}, channel: telegram)`,
+      );
+      botRunner = run(bot, {
+        sink: {
+          // @grammyjs/runner defaults to 500; keep acpella conservative because prompts spawn child agents.
+          concurrency: 5,
+        },
+      });
     },
-  });
-  await botRunner.task();
+    wait: async () => {
+      await botRunner?.task();
+    },
+    stop: async () => {
+      await botRunner?.stop();
+    },
+  };
 }
 
-async function serveDiscord(options: {
+async function createDiscordService(options: {
   config: AppConfig;
   handler: Handler;
   version: string;
   registerCronDeliveryHandler: (handler: CronDeliveryHandler) => void;
-}) {
+}): Promise<ChannelService> {
   const { config, handler, version, registerCronDeliveryHandler } = options;
-
-  if (!config.discord.token) {
-    throw new Error("ACPELLA_DISCORD_BOT_TOKEN is required");
-  }
-  if (config.discord.allowedGuildIds.length === 0) {
-    throw new Error("ACPELLA_DISCORD_ALLOWED_GUILD_IDS must be non-empty");
-  }
 
   const allowedUsers = new Set(config.discord.allowedUserIds);
   const allowedGuilds = new Set(config.discord.allowedGuildIds);
@@ -522,9 +583,23 @@ async function serveDiscord(options: {
     console.error("[discord] client error", error);
   });
 
-  console.log(`Starting service (version: ${version}, home: ${config.home}, channel: discord)`);
-  await client.login(config.discord.token);
-  await new Promise<never>(() => {});
+  const discordToken = config.discord.token;
+  if (!discordToken) {
+    throw new Error("ACPELLA_DISCORD_BOT_TOKEN is required");
+  }
+
+  return {
+    start: async () => {
+      console.log(`Starting service (version: ${version}, home: ${config.home}, channel: discord)`);
+      await client.login(discordToken);
+    },
+    wait: async () => {
+      await new Promise<never>(() => {});
+    },
+    stop: () => {
+      client.destroy();
+    },
+  };
 }
 
 async function startRepl({

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -170,10 +170,14 @@ async function serveTelegram(options: {
   const allowedUsers = new Set(config.telegram.allowedUserIds);
   const allowedChats = new Set(config.telegram.allowedChatIds);
 
+  if (!config.telegram.token) {
+    throw new Error("ACPELLA_TELEGRAM_BOT_TOKEN is required");
+  }
   if (allowedUsers.size === 0) {
     throw new Error("ACPELLA_TELEGRAM_ALLOWED_USER_IDS must be non-empty");
   }
-  const telegramToken = config.telegram.token!;
+
+  const telegramToken = config.telegram.token;
   const bot = new Bot(telegramToken);
   const botInfo = await bot.api.getMe();
   const botUsername = botInfo.username;
@@ -357,12 +361,14 @@ async function serveTelegram(options: {
   });
 
   console.log(`Starting service (version: ${version}, home: ${config.home}, channel: telegram)`);
-  return run(bot, {
+
+  const botRunner = run(bot, {
     sink: {
       // @grammyjs/runner defaults to 500; keep acpella conservative because prompts spawn child agents.
       concurrency: 5,
     },
   });
+  return botRunner;
 }
 
 async function serveDiscord(options: {
@@ -373,13 +379,17 @@ async function serveDiscord(options: {
 }): Promise<Client> {
   const { config, handler, version, registerCronDeliveryHandler } = options;
 
+  if (!config.discord.token) {
+    throw new Error("ACPELLA_DISCORD_BOT_TOKEN is required");
+  }
+  if (config.discord.allowedGuildIds.length === 0) {
+    throw new Error("ACPELLA_DISCORD_ALLOWED_GUILD_IDS must be non-empty");
+  }
+
   const allowedUsers = new Set(config.discord.allowedUserIds);
   const allowedGuilds = new Set(config.discord.allowedGuildIds);
   const allowedChannels = new Set(config.discord.allowedChannelIds);
 
-  if (allowedGuilds.size === 0) {
-    throw new Error("ACPELLA_DISCORD_ALLOWED_GUILD_IDS must be non-empty");
-  }
   const client = new Client({
     intents: [
       GatewayIntentBits.Guilds,
@@ -505,9 +515,8 @@ async function serveDiscord(options: {
     console.error("[discord] client error", error);
   });
 
-  const discordToken = config.discord.token!;
   console.log(`Starting service (version: ${version}, home: ${config.home}, channel: discord)`);
-  await client.login(discordToken);
+  await client.login(config.discord.token);
   return client;
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -139,12 +139,6 @@ ${CLI_HELP}`);
 
   const channelServices: ChannelService[] = [];
   if (config.telegram.token) {
-    if (!config.telegram.token) {
-      throw new Error("ACPELLA_TELEGRAM_BOT_TOKEN is required");
-    }
-    if (config.telegram.allowedUserIds.length === 0) {
-      throw new Error("ACPELLA_TELEGRAM_ALLOWED_USER_IDS must be non-empty");
-    }
     channelServices.push(
       await createTelegramService({
         config,
@@ -155,12 +149,6 @@ ${CLI_HELP}`);
     );
   }
   if (config.discord.token) {
-    if (!config.discord.token) {
-      throw new Error("ACPELLA_DISCORD_BOT_TOKEN is required");
-    }
-    if (config.discord.allowedGuildIds.length === 0) {
-      throw new Error("ACPELLA_DISCORD_ALLOWED_GUILD_IDS must be non-empty");
-    }
     channelServices.push(
       await createDiscordService({
         config,
@@ -192,10 +180,10 @@ async function createTelegramService(options: {
   const allowedUsers = new Set(config.telegram.allowedUserIds);
   const allowedChats = new Set(config.telegram.allowedChatIds);
 
-  const telegramToken = config.telegram.token;
-  if (!telegramToken) {
-    throw new Error("ACPELLA_TELEGRAM_BOT_TOKEN is required");
+  if (allowedUsers.size === 0) {
+    throw new Error("ACPELLA_TELEGRAM_ALLOWED_USER_IDS must be non-empty");
   }
+  const telegramToken = config.telegram.token!;
   const bot = new Bot(telegramToken);
   const botInfo = await bot.api.getMe();
   const botUsername = botInfo.username;
@@ -412,6 +400,9 @@ async function createDiscordService(options: {
   const allowedGuilds = new Set(config.discord.allowedGuildIds);
   const allowedChannels = new Set(config.discord.allowedChannelIds);
 
+  if (allowedGuilds.size === 0) {
+    throw new Error("ACPELLA_DISCORD_ALLOWED_GUILD_IDS must be non-empty");
+  }
   const client = new Client({
     intents: [
       GatewayIntentBits.Guilds,
@@ -537,11 +528,7 @@ async function createDiscordService(options: {
     console.error("[discord] client error", error);
   });
 
-  const discordToken = config.discord.token;
-  if (!discordToken) {
-    throw new Error("ACPELLA_DISCORD_BOT_TOKEN is required");
-  }
-
+  const discordToken = config.discord.token!;
   return {
     start: async () => {
       console.log(`Starting service (version: ${version}, home: ${config.home}, channel: discord)`);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -41,8 +41,6 @@ Options:
   -h, --help        Show this help.
 `;
 
-type ChannelName = "telegram" | "discord";
-
 interface ChannelService {
   start: () => Promise<void>;
   wait: () => Promise<void>;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,7 @@
 import "temporal-polyfill/global";
 import path from "node:path";
 import { createInterface } from "node:readline/promises";
-import { run, type RunnerHandle } from "@grammyjs/runner";
+import { run } from "@grammyjs/runner";
 import { Client, GatewayIntentBits, Partials, type Message } from "discord.js";
 import { Bot, type Context, type Filter } from "grammy";
 import { loadConfig, type AppConfig } from "./config.ts";
@@ -165,7 +165,7 @@ async function serveTelegram(options: {
   handler: Handler;
   version: string;
   registerCronDeliveryHandler: (handler: CronDeliveryHandler) => void;
-}): Promise<RunnerHandle> {
+}) {
   const { config, handler, version, registerCronDeliveryHandler } = options;
   const allowedUsers = new Set(config.telegram.allowedUserIds);
   const allowedChats = new Set(config.telegram.allowedChatIds);
@@ -376,7 +376,7 @@ async function serveDiscord(options: {
   handler: Handler;
   version: string;
   registerCronDeliveryHandler: (handler: CronDeliveryHandler) => void;
-}): Promise<Client> {
+}) {
   const { config, handler, version, registerCronDeliveryHandler } = options;
 
   if (!config.discord.token) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -131,22 +131,23 @@ ${CLI_HELP}`);
     return;
   }
 
+  const channelNames: string[] = [];
   const channelTasks: Promise<void>[] = [];
   if (config.telegram.token) {
+    channelNames.push("telegram");
     const botRunner = await serveTelegram({
       config,
       handler,
-      version,
       registerCronDeliveryHandler,
     });
     cleanup.defer(() => botRunner.stop());
     channelTasks.push(botRunner.task()!);
   }
   if (config.discord.token) {
+    channelNames.push("discord");
     const client = await serveDiscord({
       config,
       handler,
-      version,
       registerCronDeliveryHandler,
     });
     cleanup.defer(() => client.destroy());
@@ -156,6 +157,9 @@ ${CLI_HELP}`);
     throw new Error("No service channels configured. Configure Telegram or Discord credentials.");
   }
 
+  console.log(
+    `Starting service (version: ${version}, home: ${config.home}, channels: ${channelNames.join(", ")})`,
+  );
   cronRunner.start();
   await Promise.all(channelTasks);
 }
@@ -163,10 +167,9 @@ ${CLI_HELP}`);
 async function serveTelegram(options: {
   config: AppConfig;
   handler: Handler;
-  version: string;
   registerCronDeliveryHandler: (handler: CronDeliveryHandler) => void;
 }) {
-  const { config, handler, version, registerCronDeliveryHandler } = options;
+  const { config, handler, registerCronDeliveryHandler } = options;
   const allowedUsers = new Set(config.telegram.allowedUserIds);
   const allowedChats = new Set(config.telegram.allowedChatIds);
 
@@ -360,8 +363,6 @@ async function serveTelegram(options: {
     });
   });
 
-  console.log(`Starting service (version: ${version}, home: ${config.home}, channel: telegram)`);
-
   const botRunner = run(bot, {
     sink: {
       // @grammyjs/runner defaults to 500; keep acpella conservative because prompts spawn child agents.
@@ -374,10 +375,9 @@ async function serveTelegram(options: {
 async function serveDiscord(options: {
   config: AppConfig;
   handler: Handler;
-  version: string;
   registerCronDeliveryHandler: (handler: CronDeliveryHandler) => void;
 }) {
-  const { config, handler, version, registerCronDeliveryHandler } = options;
+  const { config, handler, registerCronDeliveryHandler } = options;
 
   if (!config.discord.token) {
     throw new Error("ACPELLA_DISCORD_BOT_TOKEN is required");
@@ -515,7 +515,6 @@ async function serveDiscord(options: {
     console.error("[discord] client error", error);
   });
 
-  console.log(`Starting service (version: ${version}, home: ${config.home}, channel: discord)`);
   await client.login(config.discord.token);
   return client;
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -41,12 +41,6 @@ Options:
   -h, --help        Show this help.
 `;
 
-interface ChannelService {
-  start: () => Promise<void>;
-  wait: () => Promise<void>;
-  stop: () => Promise<void> | void;
-}
-
 async function main() {
   const cliArgv = process.argv.slice(2);
   if (cliArgv.some((arg) => ["-h", "--help"].includes(arg))) {
@@ -137,45 +131,41 @@ ${CLI_HELP}`);
     return;
   }
 
-  const channelServices: ChannelService[] = [];
+  const channelTasks: Promise<void>[] = [];
   if (config.telegram.token) {
-    channelServices.push(
-      await createTelegramService({
-        config,
-        handler,
-        version,
-        registerCronDeliveryHandler,
-      }),
-    );
+    const botRunner = await serveTelegram({
+      config,
+      handler,
+      version,
+      registerCronDeliveryHandler,
+    });
+    cleanup.defer(() => botRunner.stop());
+    channelTasks.push(botRunner.task()!);
   }
   if (config.discord.token) {
-    channelServices.push(
-      await createDiscordService({
-        config,
-        handler,
-        version,
-        registerCronDeliveryHandler,
-      }),
-    );
+    const client = await serveDiscord({
+      config,
+      handler,
+      version,
+      registerCronDeliveryHandler,
+    });
+    cleanup.defer(() => client.destroy());
+    channelTasks.push(new Promise<never>(() => {}));
   }
-  if (channelServices.length === 0) {
+  if (channelTasks.length === 0) {
     throw new Error("No service channels configured. Configure Telegram or Discord credentials.");
   }
-  for (const service of channelServices) {
-    cleanup.defer(() => service.stop());
-  }
 
-  await Promise.all(channelServices.map((service) => service.start()));
   cronRunner.start();
-  await Promise.all(channelServices.map((service) => service.wait()));
+  await Promise.all(channelTasks);
 }
 
-async function createTelegramService(options: {
+async function serveTelegram(options: {
   config: AppConfig;
   handler: Handler;
   version: string;
   registerCronDeliveryHandler: (handler: CronDeliveryHandler) => void;
-}): Promise<ChannelService> {
+}): Promise<RunnerHandle> {
   const { config, handler, version, registerCronDeliveryHandler } = options;
   const allowedUsers = new Set(config.telegram.allowedUserIds);
   const allowedChats = new Set(config.telegram.allowedChatIds);
@@ -366,34 +356,21 @@ async function createTelegramService(options: {
     });
   });
 
-  let botRunner: RunnerHandle | undefined;
-  return {
-    start: async () => {
-      console.log(
-        `Starting service (version: ${version}, home: ${config.home}, channel: telegram)`,
-      );
-      botRunner = run(bot, {
-        sink: {
-          // @grammyjs/runner defaults to 500; keep acpella conservative because prompts spawn child agents.
-          concurrency: 5,
-        },
-      });
+  console.log(`Starting service (version: ${version}, home: ${config.home}, channel: telegram)`);
+  return run(bot, {
+    sink: {
+      // @grammyjs/runner defaults to 500; keep acpella conservative because prompts spawn child agents.
+      concurrency: 5,
     },
-    wait: async () => {
-      await botRunner?.task();
-    },
-    stop: async () => {
-      await botRunner?.stop();
-    },
-  };
+  });
 }
 
-async function createDiscordService(options: {
+async function serveDiscord(options: {
   config: AppConfig;
   handler: Handler;
   version: string;
   registerCronDeliveryHandler: (handler: CronDeliveryHandler) => void;
-}): Promise<ChannelService> {
+}): Promise<Client> {
   const { config, handler, version, registerCronDeliveryHandler } = options;
 
   const allowedUsers = new Set(config.discord.allowedUserIds);
@@ -529,18 +506,9 @@ async function createDiscordService(options: {
   });
 
   const discordToken = config.discord.token!;
-  return {
-    start: async () => {
-      console.log(`Starting service (version: ${version}, home: ${config.home}, channel: discord)`);
-      await client.login(discordToken);
-    },
-    wait: async () => {
-      await new Promise<never>(() => {});
-    },
-    stop: () => {
-      client.destroy();
-    },
-  };
+  console.log(`Starting service (version: ${version}, home: ${config.home}, channel: discord)`);
+  await client.login(discordToken);
+  return client;
 }
 
 async function startRepl({

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -138,11 +138,7 @@ ${CLI_HELP}`);
   }
 
   const channelServices: ChannelService[] = [];
-  if (
-    Boolean(config.telegram.token) ||
-    config.telegram.allowedUserIds.length > 0 ||
-    config.telegram.allowedChatIds.length > 0
-  ) {
+  if (config.telegram.token) {
     if (!config.telegram.token) {
       throw new Error("ACPELLA_TELEGRAM_BOT_TOKEN is required");
     }
@@ -158,12 +154,7 @@ ${CLI_HELP}`);
       }),
     );
   }
-  if (
-    Boolean(config.discord.token) ||
-    config.discord.allowedUserIds.length > 0 ||
-    config.discord.allowedGuildIds.length > 0 ||
-    config.discord.allowedChannelIds.length > 0
-  ) {
+  if (config.discord.token) {
     if (!config.discord.token) {
       throw new Error("ACPELLA_DISCORD_BOT_TOKEN is required");
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -156,7 +156,6 @@ ${CLI_HELP}`);
   if (channelTasks.length === 0) {
     throw new Error("No service channels configured. Configure Telegram or Discord credentials.");
   }
-
   console.log(
     `Starting service (version: ${version}, home: ${config.home}, channels: ${channelNames.join(", ")})`,
   );

--- a/src/lib/cli.ts
+++ b/src/lib/cli.ts
@@ -2,8 +2,6 @@ type ParsedCli = {
   command: string;
   args: string[];
   envFile?: string;
-  channel?: string;
-  noCron: boolean;
 };
 
 export function parseCli(options: {
@@ -12,8 +10,6 @@ export function parseCli(options: {
   defaultCommand?: string;
 }): ParsedCli {
   let envFile: string | undefined;
-  let channel: string | undefined;
-  let noCron = false;
   const argv: string[] = [];
   for (const arg of options.argv) {
     if (arg.startsWith("--env-file=")) {
@@ -22,18 +18,6 @@ export function parseCli(options: {
         throw new Error("Missing value for --env-file");
       }
       envFile = value;
-      continue;
-    }
-    if (arg.startsWith("--channel=")) {
-      const value = arg.slice("--channel=".length);
-      if (!value) {
-        throw new Error("Missing value for --channel");
-      }
-      channel = value;
-      continue;
-    }
-    if (arg === "--no-cron") {
-      noCron = true;
       continue;
     }
     argv.push(arg);
@@ -52,7 +36,5 @@ export function parseCli(options: {
     command,
     args,
     envFile,
-    channel,
-    noCron,
   };
 }

--- a/src/test/cli/basic.test.ts
+++ b/src/test/cli/basic.test.ts
@@ -81,7 +81,7 @@ test("serve fails with partial discord env", async ({ onTestFinished }) => {
   await expect(cli.cli("serve").catch(sanitizeCliError)).resolves
     .toThrowErrorMatchingInlineSnapshot(`
     "Command failed: pnpm -s dev serve
-    Error: ACPELLA_DISCORD_BOT_TOKEN is required"
+    Error: No service channels configured. Configure Telegram or Discord credentials."
   `);
   delete process.env.ACPELLA_DISCORD_ALLOWED_GUILD_IDS;
   process.env.ACPELLA_DISCORD_BOT_TOKEN = "ok";

--- a/src/test/cli/basic.test.ts
+++ b/src/test/cli/basic.test.ts
@@ -15,8 +15,6 @@ test("help", async () => {
 
     Options:
       --env-file=<path> Use this env file for config resolution.
-      --channel=<name>  Service channel for \`serve\` (telegram or discord, default: telegram).
-      --no-cron         Disable cron runner for this process.
       -h, --help        Show this help.
 
     "
@@ -35,20 +33,31 @@ test("cli error", async () => {
     "Command failed: pnpm -s dev yay
     Error: Unknown command: yay"
   `);
-  await expect(cli.cli("repl", "--no-cron").catch(sanitizeCliError)).resolves
+  await expect(cli.cli("serve", "--channel=discord").catch(sanitizeCliError)).resolves
     .toThrowErrorMatchingInlineSnapshot(`
-      "Command failed: pnpm -s dev repl --no-cron
-      Error: --no-cron can only be used with serve"
+      "Command failed: pnpm -s dev serve --channel=discord
+      Error: Unexpected arguments for serve: --channel=discord
+
+      Usage: acpella [command]
+
+      Commands:
+        serve             Run bot service. Default when no command is provided.
+        repl              Run local in-process REPL.
+        exec <message...> Run one local message, then exit.
+
+      Options:
+        --env-file=<path> Use this env file for config resolution.
+        -h, --help        Show this help."
     `);
 });
 
-test("serve fails without telegram env", async ({ onTestFinished }) => {
+test("serve fails without channel env", async ({ onTestFinished }) => {
   const cli = useCli();
   expect(process.env.ACPELLA_TELEGRAM_BOT_TOKEN).toBe(undefined);
   await expect(cli.cli("serve").catch(sanitizeCliError)).resolves
     .toThrowErrorMatchingInlineSnapshot(`
     "Command failed: pnpm -s dev serve
-    Error: ACPELLA_TELEGRAM_BOT_TOKEN is required"
+    Error: No service channels configured. Configure Telegram or Discord credentials."
   `);
   process.env.ACPELLA_TELEGRAM_BOT_TOKEN = "ok";
   onTestFinished(() => {
@@ -62,22 +71,27 @@ test("serve fails without telegram env", async ({ onTestFinished }) => {
     `);
 });
 
-test("serve fails without discord env", async ({ onTestFinished }) => {
+test("serve fails with partial discord env", async ({ onTestFinished }) => {
   const cli = useCli();
   expect(process.env.ACPELLA_DISCORD_BOT_TOKEN).toBe(undefined);
-  await expect(cli.cli("serve", "--channel=discord").catch(sanitizeCliError)).resolves
+  process.env.ACPELLA_DISCORD_ALLOWED_GUILD_IDS = "123";
+  onTestFinished(() => {
+    delete process.env.ACPELLA_DISCORD_ALLOWED_GUILD_IDS;
+  });
+  await expect(cli.cli("serve").catch(sanitizeCliError)).resolves
     .toThrowErrorMatchingInlineSnapshot(`
-    "Command failed: pnpm -s dev serve --channel=discord
+    "Command failed: pnpm -s dev serve
     Error: ACPELLA_DISCORD_BOT_TOKEN is required"
   `);
+  delete process.env.ACPELLA_DISCORD_ALLOWED_GUILD_IDS;
   process.env.ACPELLA_DISCORD_BOT_TOKEN = "ok";
   onTestFinished(() => {
     delete process.env.ACPELLA_DISCORD_BOT_TOKEN;
   });
   expect(process.env.ACPELLA_DISCORD_ALLOWED_GUILD_IDS).toBe(undefined);
-  await expect(cli.cli("serve", "--channel=discord").catch(sanitizeCliError)).resolves
+  await expect(cli.cli("serve").catch(sanitizeCliError)).resolves
     .toThrowErrorMatchingInlineSnapshot(`
-      "Command failed: pnpm -s dev serve --channel=discord
+      "Command failed: pnpm -s dev serve
       Error: ACPELLA_DISCORD_ALLOWED_GUILD_IDS must be non-empty"
     `);
 });

--- a/src/test/cli/basic.test.ts
+++ b/src/test/cli/basic.test.ts
@@ -74,16 +74,11 @@ test("serve fails without channel env", async ({ onTestFinished }) => {
 test("serve fails with partial discord env", async ({ onTestFinished }) => {
   const cli = useCli();
   expect(process.env.ACPELLA_DISCORD_BOT_TOKEN).toBe(undefined);
-  process.env.ACPELLA_DISCORD_ALLOWED_GUILD_IDS = "123";
-  onTestFinished(() => {
-    delete process.env.ACPELLA_DISCORD_ALLOWED_GUILD_IDS;
-  });
   await expect(cli.cli("serve").catch(sanitizeCliError)).resolves
     .toThrowErrorMatchingInlineSnapshot(`
     "Command failed: pnpm -s dev serve
     Error: No service channels configured. Configure Telegram or Discord credentials."
   `);
-  delete process.env.ACPELLA_DISCORD_ALLOWED_GUILD_IDS;
   process.env.ACPELLA_DISCORD_BOT_TOKEN = "ok";
   onTestFinished(() => {
     delete process.env.ACPELLA_DISCORD_BOT_TOKEN;


### PR DESCRIPTION
- closes #273

## Summary

- remove the temporary `--channel` and `--no-cron` serve flags
- make `acpella serve` start all fully configured channels from one process
- register channel cron delivery handlers before starting cron
- update CLI expectations and operator docs for the new serve behavior
