### PR TITLE
feat: default `/cron list` to compact output

### DIFF
--- a/skills/acpella/references/cron.md
+++ b/skills/acpella/references/cron.md
@@ -17,7 +17,7 @@ Use:
 - `/cron stop`
 - `/cron add <id> <minute> <hour> <day-of-month> <month> <day-of-week> [--once] [--target <sessionName>] -- <prompt...>`
 - `/cron update <id> <minute> <hour> <day-of-month> <month> <day-of-week> [--target <sessionName>] [-- <prompt...>]`
-- `/cron list [--compact]`
+- `/cron list [--full]`
 - `/cron show <id>`
 - `/cron enable <id>`
 - `/cron disable <id>`
@@ -57,13 +57,13 @@ Add `--once` to make a job self-disable after its first execution, whether the r
 acpella exec '/cron add remind-deploy 0 14 5 * * --once --target tg-123456789 -- Remind the team to deploy the release.'
 ```
 
-After the job fires, `/cron show remind-deploy` will show `once: yes` and `/cron list` will show `[disabled, once]`. Use `/cron enable remind-deploy` to arm it again for another single run.
+After the job fires, `/cron show remind-deploy` will show `once: yes` and `/cron list` will show the disabled one-shot job in the compact disabled section. Use `/cron enable remind-deploy` to arm it again for another single run.
 
 ## Common workflow
 
 1. Find the target session with `acpella exec /session list` if creating the job from local shell administration; if more than one candidate could match, confirm with the user before continuing.
 2. Add the job with `acpella exec '/cron add ... --target <sessionName> -- <prompt...>'` for actual Telegram delivery.
-3. Check it with `/cron show <id>`, `/cron list`, or `/cron list --compact` for a timeline-style summary sorted by next run.
+3. Check it with `/cron show <id>`, use `/cron list` for a timeline-style summary sorted by next run, or use `/cron list --full` for detailed metadata.
 4. Use `/cron update <id> <minute> <hour> <day-of-month> <month> <day-of-week> ...` to change its schedule, destination, or prompt.
 5. Use `/cron disable <id>` when you want to pause it.
 6. Use `/cron enable <id>` to resume it.

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -668,7 +668,7 @@ enabled jobs: ${enabledJobs.length}
     },
     {
       tokens: ["list"],
-      usage: "/cron list [--compact]",
+      usage: "/cron list [--full]",
       description: "List cron jobs.",
       withArgs: true,
       run: async ({ args, reply }) => {

--- a/src/lib/cron/command.ts
+++ b/src/lib/cron/command.ts
@@ -60,10 +60,10 @@ export function parseCronIdArg(args: string[]): string {
 
 export function parseCronListArgs(args: string[]) {
   if (args.length === 0) {
-    return { compact: false };
-  }
-  if (args.length === 1 && args[0] === "--compact") {
     return { compact: true };
+  }
+  if (args.length === 1 && args[0] === "--full") {
+    return { compact: false };
   }
   throw new Error("Invalid arguments");
 }

--- a/src/test/cron.test.ts
+++ b/src/test/cron.test.ts
@@ -209,9 +209,6 @@ test("cron command", async ({ onTestFinished }) => {
     "[⚙️ System]
     Apr 18 (Sat) | 07:01 | test-job"
   `);
-  await expect(session.request("/cron list --compact")).rejects.toMatchInlineSnapshot(
-    `[Error: Invalid arguments]`,
-  );
   expect(await session.request("/cron show test-job")).toMatchInlineSnapshot(`
     "[⚙️ System]
     id: test-job

--- a/src/test/cron.test.ts
+++ b/src/test/cron.test.ts
@@ -76,7 +76,7 @@ test("cron auto reloads external cron file changes", async ({ onTestFinished }) 
   });
 
   vi.advanceTimersByTime(1250);
-  expect(await session.request("/cron list")).toMatchInlineSnapshot(`
+  expect(await session.request("/cron list --full")).toMatchInlineSnapshot(`
     "[⚙️ System]
     - file-job [enabled]
       schedule: 2 * * * *
@@ -113,7 +113,7 @@ test("cron auto reloads external cron file changes", async ({ onTestFinished }) 
       ]
     `);
   }
-  expect(await session.request("/cron list")).toMatchInlineSnapshot(`
+  expect(await session.request("/cron list --full")).toMatchInlineSnapshot(`
     "[⚙️ System]
     - file-job [enabled]
       schedule: 2 * * * *
@@ -195,7 +195,7 @@ test("cron command", async ({ onTestFinished }) => {
     "[⚙️ System]
     Added cron job: test-job"
   `);
-  expect(await session.request("/cron list")).toMatchInlineSnapshot(`
+  expect(await session.request("/cron list --full")).toMatchInlineSnapshot(`
     "[⚙️ System]
     - test-job [enabled]
       schedule: * * * * *
@@ -205,10 +205,13 @@ test("cron command", async ({ onTestFinished }) => {
       next: 2026-04-18T07:01:00+07:00
       last: none"
   `);
-  expect(await session.request("/cron list --compact")).toMatchInlineSnapshot(`
+  expect(await session.request("/cron list")).toMatchInlineSnapshot(`
     "[⚙️ System]
     Apr 18 (Sat) | 07:01 | test-job"
   `);
+  await expect(session.request("/cron list --compact")).rejects.toMatchInlineSnapshot(
+    `[Error: Invalid arguments]`,
+  );
   expect(await session.request("/cron show test-job")).toMatchInlineSnapshot(`
     "[⚙️ System]
     id: test-job
@@ -287,7 +290,7 @@ test("cron command", async ({ onTestFinished }) => {
     "[⚙️ System]
     Disabled cron job: test-job"
   `);
-  expect(await session.request("/cron list")).toMatchInlineSnapshot(`
+  expect(await session.request("/cron list --full")).toMatchInlineSnapshot(`
     "[⚙️ System]
     - test-job [disabled]
       schedule: * * * * *
@@ -305,7 +308,7 @@ test("cron command", async ({ onTestFinished }) => {
       next: 2026-04-18T07:03:00+07:00
       last: none"
   `);
-  expect(await session.request("/cron list --compact")).toMatchInlineSnapshot(`
+  expect(await session.request("/cron list")).toMatchInlineSnapshot(`
     "[⚙️ System]
     Apr 18 (Sat) | 07:03 | other-job
 
@@ -404,7 +407,7 @@ test("cron command", async ({ onTestFinished }) => {
     ",
     ]
   `);
-  expect(await session.request("/cron list")).toMatchInlineSnapshot(`
+  expect(await session.request("/cron list --full")).toMatchInlineSnapshot(`
     "[⚙️ System]
     - test-job [disabled]
       schedule: * * * * *
@@ -437,7 +440,7 @@ test("cron command", async ({ onTestFinished }) => {
     "[⚙️ System]
     Deleted cron job: test-job"
   `);
-  expect(await session.request("/cron list")).toMatchInlineSnapshot(`
+  expect(await session.request("/cron list --full")).toMatchInlineSnapshot(`
     "[⚙️ System]
     - other-job [enabled]
       schedule: 4 * * * *
@@ -546,7 +549,7 @@ test("cron error delivery", async ({ onTestFinished }) => {
     }
     prompt: __throw_error__"
   `);
-  expect(await session.request("/cron list --compact")).toMatchInlineSnapshot(`
+  expect(await session.request("/cron list")).toMatchInlineSnapshot(`
     "[⚙️ System]
     Apr 18 (Sat) | 07:02 | test-job (failed)"
   `);
@@ -859,7 +862,7 @@ test("cron one-shot: disabled after successful run", async ({ onTestFinished }) 
     last: none
     prompt: __raw:NO_REPLY"
   `);
-  expect(await session.request("/cron list")).toMatchInlineSnapshot(`
+  expect(await session.request("/cron list --full")).toMatchInlineSnapshot(`
     "[⚙️ System]
     - once-job [enabled, once]
       schedule: * * * * *
@@ -869,7 +872,7 @@ test("cron one-shot: disabled after successful run", async ({ onTestFinished }) 
       next: 2026-04-18T07:01:00+07:00
       last: none"
   `);
-  expect(await session.request("/cron list --compact")).toMatchInlineSnapshot(`
+  expect(await session.request("/cron list")).toMatchInlineSnapshot(`
     "[⚙️ System]
     Apr 18 (Sat) | 07:01 | once-job (once)"
   `);
@@ -893,7 +896,7 @@ test("cron one-shot: disabled after successful run", async ({ onTestFinished }) 
     last: succeeded, scheduled 2026-04-18T07:01:00+07:00, finished 2026-04-18T07:01:00+07:00
     prompt: __raw:NO_REPLY"
   `);
-  expect(await session.request("/cron list")).toMatchInlineSnapshot(`
+  expect(await session.request("/cron list --full")).toMatchInlineSnapshot(`
     "[⚙️ System]
     - once-job [disabled, once]
       schedule: * * * * *
@@ -903,7 +906,7 @@ test("cron one-shot: disabled after successful run", async ({ onTestFinished }) 
       next: none
       last: succeeded, scheduled 2026-04-18T07:01:00+07:00, finished 2026-04-18T07:01:00+07:00"
   `);
-  expect(await session.request("/cron list --compact")).toMatchInlineSnapshot(`
+  expect(await session.request("/cron list")).toMatchInlineSnapshot(`
     "[⚙️ System]
     disabled:
     - once-job (once)"

--- a/src/test/handler.test.ts
+++ b/src/test/handler.test.ts
@@ -110,7 +110,7 @@ test("basic", async () => {
       /cron stop - Stop cron scheduler.
       /cron add <id> <minute> <hour> <day-of-month> <month> <day-of-week> [--once] [--target <sessionName>] -- <prompt...> - Add a cron job.
       /cron update <id> <minute> <hour> <day-of-month> <month> <day-of-week> [--target <sessionName>] [-- <prompt...>] - Update a cron job.
-      /cron list [--compact] - List cron jobs.
+      /cron list [--full] - List cron jobs.
       /cron show <id> - Show a cron job.
       /cron enable <id> - Enable a cron job.
       /cron disable <id> - Disable a cron job.


### PR DESCRIPTION
## Summary
- make `/cron list` render the compact timeline by default
- add `/cron list --full` for detailed metadata output
- remove `--compact` from the accepted list flags and update docs/help snapshots

## Tests
- `pnpm vitest run src/test/cron.test.ts src/test/handler.test.ts -u`
- `pnpm lint`

Closes #270